### PR TITLE
Fix for Python3.

### DIFF
--- a/apkid/__init__.py
+++ b/apkid/__init__.py
@@ -51,7 +51,7 @@ def main():
     args = parser.parse_args()
 
     if not args.json:
-        print "[+] APKiD %s :: from RedNaga :: rednaga.io" % __version__
+        print("[+] APKiD %s :: from RedNaga :: rednaga.io" % __version__)
 
     for input in args.input:
         if args.output_dir:


### PR DESCRIPTION
The ``print`` of Python2-style will crash when install in Python3.