### PR TITLE
OLLVM rules & Native obfuscators Yara file created (elf/obfuscators.y…

### DIFF
--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -81,7 +81,7 @@ rule ollvm_v4_0 : obfuscator
 rule ollvm_v6_0 : obfuscator
 {
   meta:
-    description = "Obfuscator-LLVM version 6.x"
+    description = "Obfuscator-LLVM version 6.0"
     info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = ""
     // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"
@@ -98,7 +98,7 @@ rule ollvm_v6_0 : obfuscator
 rule ollvm_v6_0_strenc : obfuscator
 {
   meta:
-    description = "Obfuscator-LLVM version 6.x (string encryption)"
+    description = "Obfuscator-LLVM version 6.0 (string encryption)"
     info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = "f3a2e6c57def9a8b4730965dd66ca0f243689153139758c44718b8c5ef9c1d17"
     // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -90,7 +90,7 @@ rule ollvm_v6_0 : obfuscator
   strings:
     $clang_version = "Obfuscator-LLVM clang version 6"
     $based_on      = "(based on Obfuscator-LLVM 6"
-    $strenc        = /.datadiv_decode[0-9]{18,20}/
+    $strenc        = /datadiv_decode[0-9]{18,20}/
 
   condition:
     ($clang_version and $based_on) and not $strenc

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -26,31 +26,35 @@
  **/
 
 
+
 rule ollvm_v3_4 : obfuscator
 {
   meta:
-    description = "Obfuscator-LLVM version 3.4 svn"
-    info = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    description = "Obfuscator-LLVM version 3.4"
+    info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    example     = "cd16ad33bf203dbaa9add803a7a0740e3727e8e60c316d33206230ae5b985f25"
     // "Obfuscator-clang version 3.4 (tags/RELEASE_34/final) (based on LLVM 3.4svn)"
 
   strings:
     $clang_version = "Obfuscator-clang version 3.4"
-    $based_on = "(based on LLVM 3.4svn)"
+    $based_on      = "(based on LLVM 3.4"
 
   condition:
     all of them
 }
 
+
 rule ollvm_v3_6_1 : obfuscator
 {
   meta:
     description = "Obfuscator-LLVM version 3.6.1"
-    info = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    example     = "d84b45856b5c95f7a6e96ab0461648f22ad29d1c34a8e85588dad3d89f829208"
     // "Obfuscator-LLVM clang version 3.6.1 (tags/RELEASE_361/final) (based on Obfuscator-LLVM 3.6.1)"
 
   strings:
     $clang_version = "Obfuscator-LLVM clang version 3.6.1"
-    $based_on = "(based on Obfuscator-LLVM 3.6.1)"
+    $based_on      = "(based on Obfuscator-LLVM 3.6.1)"
 
   condition:
     all of them
@@ -60,13 +64,31 @@ rule ollvm_v3_6_1 : obfuscator
 rule ollvm_v4_0 : obfuscator
 {
   meta:
-    description = "Obfuscator-LLVM version 4"
-    info = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    description = "Obfuscator-LLVM version 4.x"
+    info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    example     = "aaba570388d0fe25df45480ecf894625be7affefaba24695d8c1528b974c00df"
     // "Obfuscator-LLVM clang version 4.0.1  (based on Obfuscator-LLVM 4.0.1)"
 
   strings:
     $clang_version = "Obfuscator-LLVM clang version 4"
-    $based_on = "(based on Obfuscator-LLVM"
+    $based_on      = "(based on Obfuscator-LLVM"
+
+  condition:
+    all of them
+}
+
+
+rule ollvm_v6_0 : obfuscator
+{
+  meta:
+    description = "Obfuscator-LLVM version 6.x"
+    info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    example     = "f3a2e6c57def9a8b4730965dd66ca0f243689153139758c44718b8c5ef9c1d17"
+    // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"
+
+  strings:
+    $clang_version = "Obfuscator-LLVM clang version 6"
+    $based_on      = "(based on Obfuscator-LLVM 6"
 
   condition:
     all of them
@@ -76,16 +98,19 @@ rule ollvm_v4_0 : obfuscator
 rule ollvm : obfuscator
 {
   meta:
-    description = "Obfuscator-LLVM"
-    info = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    description = "Obfuscator-LLVM version unknown"
+    info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
 
   strings:
-    $ollvm = "Obfuscator-LLVM"
+    $ollvm1 = "Obfuscator-LLVM "
+    $ollvm2 = "Obfuscator-clang "
 
   condition:
-    $ollvm and
+    ($ollvm1 or $ollvm2) and
     not ollvm_v3_4 and
     not ollvm_v3_6_1 and
-    not ollvm_v4_0
+    not ollvm_v4_0 and
+    not ollvm_v6_0
 }
+
 

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2017  RedNaga. http://rednaga.io
+ * All rights reserved. Contact: rednaga@protonmail.com
+ *
+ *
+ * This file is part of APKiD
+ *
+ *
+ * Commercial License Usage
+ * ------------------------
+ * Licensees holding valid commercial APKiD licenses may use this file
+ * in accordance with the commercial license agreement provided with the
+ * Software or, alternatively, in accordance with the terms contained in
+ * a written agreement between you and RedNaga.
+ *
+ *
+ * GNU General Public License Usage
+ * --------------------------------
+ * Alternatively, this file may be used under the terms of the GNU General
+ * Public License version 3.0 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.GPL included in the packaging of this
+ * file. Please visit http://www.gnu.org/copyleft/gpl.html and review the
+ * information to ensure the GNU General Public License version 3.0
+ * requirements will be met.
+ *
+ **/
+
+
+rule ollvm_v3_4 : obfuscator
+{
+  meta:
+    description = "Obfuscator-LLVM version 3.4 svn"
+    // "Obfuscator-clang version 3.4 (tags/RELEASE_34/final) (based on LLVM 3.4svn)"
+
+  strings:
+    $clang_version = "Obfuscator-clang version 3.4"
+    $based_on = "(based on LLVM 3.4svn)"
+
+  condition:
+    all of them
+}
+
+rule ollvm_v3_6_1 : obfuscator
+{
+  meta:
+    description = "Obfuscator-LLVM version 3.6.1"
+    // "Obfuscator-LLVM clang version 3.6.1 (tags/RELEASE_361/final) (based on Obfuscator-LLVM 3.6.1)"
+
+  strings:
+    $clang_version = "Obfuscator-LLVM clang version 3.6.1"
+    $based_on = "(based on Obfuscator-LLVM 3.6.1)"
+
+  condition:
+    all of them
+}
+
+
+rule ollvm_v4_0 : obfuscator
+{
+  meta:
+    description = "Obfuscator-LLVM version 4"
+    info = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    // "Obfuscator-LLVM clang version 4.0.1  (based on Obfuscator-LLVM 4.0.1)"
+
+  strings:
+    $clang_version = "Obfuscator-LLVM clang version 4"
+    $based_on = "(based on Obfuscator-LLVM"
+
+  condition:
+    all of them
+}
+
+
+rule ollvm : obfuscator
+{
+  meta:
+    description = "Obfuscator-LLVM"
+    info = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+
+  strings:
+    $ollvm = "Obfuscator-LLVM"
+
+  condition:
+    $ollvm and
+    not ollvm_v3_4 and 
+    not ollvm_v3_6_1 and
+    not ollvm_v4_0
+}
+

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -30,6 +30,7 @@ rule ollvm_v3_4 : obfuscator
 {
   meta:
     description = "Obfuscator-LLVM version 3.4 svn"
+    info = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     // "Obfuscator-clang version 3.4 (tags/RELEASE_34/final) (based on LLVM 3.4svn)"
 
   strings:
@@ -44,6 +45,7 @@ rule ollvm_v3_6_1 : obfuscator
 {
   meta:
     description = "Obfuscator-LLVM version 3.6.1"
+    info = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     // "Obfuscator-LLVM clang version 3.6.1 (tags/RELEASE_361/final) (based on Obfuscator-LLVM 3.6.1)"
 
   strings:
@@ -82,7 +84,7 @@ rule ollvm : obfuscator
 
   condition:
     $ollvm and
-    not ollvm_v3_4 and 
+    not ollvm_v3_4 and
     not ollvm_v3_6_1 and
     not ollvm_v4_0
 }

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -83,7 +83,7 @@ rule ollvm_v6_0 : obfuscator
   meta:
     description = "Obfuscator-LLVM version 6.x"
     info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
-    example     = "f3a2e6c57def9a8b4730965dd66ca0f243689153139758c44718b8c5ef9c1d17"
+    example     = ""
     // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"
 
   strings:

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -85,6 +85,7 @@ rule ollvm_v6_0 : obfuscator
     info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = ""
     // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"
+    // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0)"
 
   strings:
     $clang_version = "Obfuscator-LLVM clang version 6"
@@ -102,6 +103,7 @@ rule ollvm_v6_0_strenc : obfuscator
     info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = "f3a2e6c57def9a8b4730965dd66ca0f243689153139758c44718b8c5ef9c1d17"
     // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"
+    // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0)"
 
   strings:
     $clang_version = "Obfuscator-LLVM clang version 6"

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -89,6 +89,24 @@ rule ollvm_v6_0 : obfuscator
   strings:
     $clang_version = "Obfuscator-LLVM clang version 6"
     $based_on      = "(based on Obfuscator-LLVM 6"
+    $strenc        = /.datadiv_decode[0-9]{18,20}/
+
+  condition:
+    ($clang_version and $based_on) and not $strenc
+}
+
+rule ollvm_v6_0_strenc : obfuscator
+{
+  meta:
+    description = "Obfuscator-LLVM version 6.x (string encryption)"
+    info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    example     = "f3a2e6c57def9a8b4730965dd66ca0f243689153139758c44718b8c5ef9c1d17"
+    // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"
+
+  strings:
+    $clang_version = "Obfuscator-LLVM clang version 6"
+    $based_on      = "(based on Obfuscator-LLVM 6"
+    $strenc        = /.datadiv_decode[0-9]{18,20}/
 
   condition:
     all of them
@@ -110,7 +128,8 @@ rule ollvm : obfuscator
     not ollvm_v3_4 and
     not ollvm_v3_6_1 and
     not ollvm_v4_0 and
-    not ollvm_v6_0
+    not ollvm_v6_0 and
+    not ollvm_v6_0_strenc
 }
 
 

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -33,10 +33,10 @@ rule ollvm_v3_4 : obfuscator
     description = "Obfuscator-LLVM version 3.4"
     info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = "cd16ad33bf203dbaa9add803a7a0740e3727e8e60c316d33206230ae5b985f25"
-    // "Obfuscator-clang version 3.4 (tags/RELEASE_34/final) (based on LLVM 3.4svn)"
 
   strings:
-    $clang_version = "Obfuscator-clang version 3.4"
+    // "Obfuscator-clang version 3.4 (tags/RELEASE_34/final) (based on LLVM 3.4svn)"
+    $clang_version = "Obfuscator-clang version 3.4 "
     $based_on      = "(based on LLVM 3.4"
 
   condition:
@@ -50,10 +50,10 @@ rule ollvm_v3_6_1 : obfuscator
     description = "Obfuscator-LLVM version 3.6.1"
     info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = "d84b45856b5c95f7a6e96ab0461648f22ad29d1c34a8e85588dad3d89f829208"
-    // "Obfuscator-LLVM clang version 3.6.1 (tags/RELEASE_361/final) (based on Obfuscator-LLVM 3.6.1)"
 
   strings:
-    $clang_version = "Obfuscator-LLVM clang version 3.6.1"
+    // "Obfuscator-LLVM clang version 3.6.1 (tags/RELEASE_361/final) (based on Obfuscator-LLVM 3.6.1)"
+    $clang_version = "Obfuscator-LLVM clang version 3.6.1 "
     $based_on      = "(based on Obfuscator-LLVM 3.6.1)"
 
   condition:
@@ -64,18 +64,39 @@ rule ollvm_v3_6_1 : obfuscator
 rule ollvm_v4_0 : obfuscator
 {
   meta:
-    description = "Obfuscator-LLVM version 4.x"
+    description = "Obfuscator-LLVM version 4.0"
     info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = "aaba570388d0fe25df45480ecf894625be7affefaba24695d8c1528b974c00df"
-    // "Obfuscator-LLVM clang version 4.0.1  (based on Obfuscator-LLVM 4.0.1)"
 
   strings:
-    $clang_version = "Obfuscator-LLVM clang version 4"
-    $based_on      = "(based on Obfuscator-LLVM"
+    // "Obfuscator-LLVM clang version 4.0.1  (based on Obfuscator-LLVM 4.0.1)"
+    $clang_version = "Obfuscator-LLVM clang version 4.0.1 "
+    $based_on      = "(based on Obfuscator-LLVM 4.0.1)"
 
   condition:
     all of them
 }
+
+
+
+rule ollvm_v6_0_strenc : obfuscator
+{
+  meta:
+    description = "Obfuscator-LLVM version 6.0 (string encryption)"
+    info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    example     = "f3a2e6c57def9a8b4730965dd66ca0f243689153139758c44718b8c5ef9c1d17"
+
+  strings:
+    // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0)"
+    // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"
+    $clang_version = "Obfuscator-LLVM clang version 6.0."
+    $based_on      = "(based on Obfuscator-LLVM 6.0."
+    $strenc        = /datadiv_decode[0-9]{18,20}/
+
+  condition:
+    all of them
+}
+
 
 
 rule ollvm_v6_0 : obfuscator
@@ -84,35 +105,17 @@ rule ollvm_v6_0 : obfuscator
     description = "Obfuscator-LLVM version 6.0"
     info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = ""
-    // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"
-    // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0)"
 
   strings:
-    $clang_version = "Obfuscator-LLVM clang version 6"
-    $based_on      = "(based on Obfuscator-LLVM 6"
-    $strenc        = /datadiv_decode[0-9]{18,20}/
-
-  condition:
-    ($clang_version and $based_on) and not $strenc
-}
-
-rule ollvm_v6_0_strenc : obfuscator
-{
-  meta:
-    description = "Obfuscator-LLVM version 6.0 (string encryption)"
-    info        = "https://github.com/obfuscator-llvm/obfuscator/wiki"
-    example     = "f3a2e6c57def9a8b4730965dd66ca0f243689153139758c44718b8c5ef9c1d17"
-    // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"
     // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0)"
-
-  strings:
-    $clang_version = "Obfuscator-LLVM clang version 6"
-    $based_on      = "(based on Obfuscator-LLVM 6"
-    $strenc        = /datadiv_decode[0-9]{18,20}/
+    // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0git-b9ea5776)"
+    $clang_version = "Obfuscator-LLVM clang version 6.0."
+    $based_on      = "(based on Obfuscator-LLVM 6.0."
 
   condition:
-    all of them
+    all of them and not ollvm_v6_0_strenc
 }
+
 
 
 rule ollvm : obfuscator
@@ -133,5 +136,6 @@ rule ollvm : obfuscator
     not ollvm_v6_0 and
     not ollvm_v6_0_strenc
 }
+
 
 

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -108,7 +108,7 @@ rule ollvm_v6_0_strenc : obfuscator
   strings:
     $clang_version = "Obfuscator-LLVM clang version 6"
     $based_on      = "(based on Obfuscator-LLVM 6"
-    $strenc        = /.datadiv_decode[0-9]{18,20}/
+    $strenc        = /datadiv_decode[0-9]{18,20}/
 
   condition:
     all of them


### PR DESCRIPTION
…ara)

Ollvm rules for the following versions:
* OLLVM 4.x
* OLLVM 3.6.1
* OLLVM 3.4
* OLLVM 6.x
* OLLVM version-less