### PR TITLE
Fixed string to byte comparison on python 3.x

### DIFF
--- a/apkid/apkid.py
+++ b/apkid/apkid.py
@@ -41,9 +41,15 @@ logging.basicConfig(level=LOGGING_LEVEL,
                     stream=sys.stdout)
 
 # Magic doesn't need to be perfect. Just used to filter likely scannable files.
-ZIP_MAGIC = ['PK\x03\x04', 'PK\x05\x06', 'PK\x07\x08']
-DEX_MAGIC = ['dex\n', 'dey\n']
-ELF_MAGIC = ['\x7fELF']
+if sys.version_info >= (3, 0):
+    ZIP_MAGIC = [b'PK\x03\x04', b'PK\x05\x06', b'PK\x07\x08']
+    DEX_MAGIC = [b'dex\n', b'dey\n']
+    ELF_MAGIC = [b'\x7fELF']
+else:
+    ZIP_MAGIC = ['PK\x03\x04', 'PK\x05\x06', 'PK\x07\x08']
+    DEX_MAGIC = ['dex\n', 'dey\n']
+    ELF_MAGIC = ['\x7fELF']
+
 AXML_MAGIC = []  # TODO
 
 


### PR DESCRIPTION
Tried running the version from github on python 3.6.1 and got no results.
Adding a 'u' to convert the string to unicode allows the comparison.