### PR TITLE
apkguard bugfix

### DIFF
--- a/apkid/rules/dex/packers.yara
+++ b/apkid/rules/dex/packers.yara
@@ -85,7 +85,7 @@ rule apkguard_dex : packer
         2206 ??00       // new-instance v6, Ljava/io/File; // type@0006
         6e10 ??00 0e00  // invoke-virtual {v14}, Lyxlhycuqv/weudayy;.getFilesDir:()Ljava/io/File; // method@0019
         0c09            // move-result-object v9
-        1a0a ??00       // const-string v10, "lllllllllllllllllllllllllllllllllllllllll.zip" // string@002f
+        1a0a (2f|30) 00 // const-string v10, "lllllllllllllllllllllllllllllllllllllllll.zip" // string@002f
         7030 ??00 960a  // invoke-direct {v6, v9, v10}, Ljava/io/File;.<init>:(Ljava/io/File;Ljava/lang/String;)V // method@000a
         1a09 1900       //  const-string v9, BASE64_ENCODED_ZIP_FILE
         7120 ??00 b900  // invoke-static {v9, v11}, Landroid/util/Base64;.decode:(Ljava/lang/String;I)[B // method@0003

--- a/apkid/rules/dex/packers.yara
+++ b/apkid/rules/dex/packers.yara
@@ -85,7 +85,7 @@ rule apkguard_dex : packer
         2206 ??00       // new-instance v6, Ljava/io/File; // type@0006
         6e10 ??00 0e00  // invoke-virtual {v14}, Lyxlhycuqv/weudayy;.getFilesDir:()Ljava/io/File; // method@0019
         0c09            // move-result-object v9
-        1a0a 2f00       // const-string v10, "lllllllllllllllllllllllllllllllllllllllll.zip" // string@002f
+        1a0a ??00       // const-string v10, "lllllllllllllllllllllllllllllllllllllllll.zip" // string@002f
         7030 ??00 960a  // invoke-direct {v6, v9, v10}, Ljava/io/File;.<init>:(Ljava/io/File;Ljava/lang/String;)V // method@000a
         1a09 1900       //  const-string v9, BASE64_ENCODED_ZIP_FILE
         7120 ??00 b900  // invoke-static {v9, v11}, Landroid/util/Base64;.decode:(Ljava/lang/String;I)[B // method@0003


### PR DESCRIPTION
Found the bug (https://github.com/rednaga/APKiD/blame/master/apkid/rules/dex/packers.yara#L88) with a new sample.

Using @radare, we can see the Dalvik asm: (highlighted the byte that should be ??)
![apkguard-fix](https://user-images.githubusercontent.com/14809754/33798465-df1e38fe-dd18-11e7-97b7-ca2131291af6.png)

Previous rule:
`1a0a 2f00       // const-string v10, "lllllllllllllllllllllllllllllllllllllllll.zip"`

New rule:
`1a0a 3000       // const-string v10, "lllllllllllllllllllllllllllllllllllllllll.zip"`

Final rule
`1a0a ??00       // const-string v10, "lllllllllllllllllllllllllllllllllllllllll.zip"`

