### PR TITLE
Firehash: native VM-based protector

### DIFF
--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -26,6 +26,8 @@
  **/
 
 
+include "../dex/common.yara"
+
 
 rule ollvm_v3_4 : obfuscator
 {
@@ -136,6 +138,39 @@ rule ollvm : obfuscator
     not ollvm_v6_0 and
     not ollvm_v6_0_strenc
 }
+
+
+rule firehash : obfuscator
+{
+  meta:
+    description = "Firehash (VM-based)"
+    url         = "https://firehash.grayhash.com/"
+    example     = "38e2170a5f272ecae97dddb0dac0c1f39f7f71a4639477764a9154557106dd94" // https://firehash.grayhash.com/static/sample/dodocrackme_obfuscated.apk
+    example     = "bc6924eede0c59021db18235ee0b2423aed9d9e265f85f0e35946cc2724cccbe" // https://firehash.grayhash.com/static/sample/dodocrackme_original.apk
+
+    // plaintext  : 6352f6d0cdc85a42de3ccfd9226dfec28280aa835227acc507043a4403b7e700
+    // firehashed : c98af9a777d9633559b7903e21b61b845f7e1766afa74ef85e3380f41265e6b5
+
+    // plaintext  : 727be6789e8f4f6eab66288f957b58800e47a4bacebacc0dd700e8f9a374f116
+    // firehashed : 423dc9866d1c5f32cabfeb254030d83e11db4d807394a8ff09be47d8bfc38f18
+
+  strings:
+    //$lib = "libaurorabridge.so"
+    $segment = ".firehash"
+    $opcodes_arm = {
+        04 00 2D E5  //  STR     R0, [SP,#var_4]!
+        00 00 0F E1  //  MRS     R0, CPSR
+        01 00 51 E1  //  CMP     R1, R1
+        02 00 00 ?A  //  BNE     loc_F0854
+        00 F0 29 E1  //  MSR     CPSR_cf, R0
+        04 00 9D E4  //  LDR     R0, [SP+4+var_4],#4
+        ?? ?? ?? EA  //  B       loc_F0828
+    }
+
+  condition:
+    all of them
+}
+
 
 
 

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -146,13 +146,13 @@ rule firehash : obfuscator
 
     // original   : https://firehash.grayhash.com/static/sample/dodocrackme_original.apk
     // firehashed : https://firehash.grayhash.com/static/sample/dodocrackme_obfuscated.apk
-    example1    = "38e2170a5f272ecae97dddb0dac0c1f39f7f71a4639477764a9154557106dd94"
+    example1   = "38e2170a5f272ecae97dddb0dac0c1f39f7f71a4639477764a9154557106dd94"
 
     // original : 6352f6d0cdc85a42de3ccfd9226dfec28280aa835227acc507043a4403b7e700
-    example2    = "c98af9a777d9633559b7903e21b61b845f7e1766afa74ef85e3380f41265e6b5"
+    example2   = "c98af9a777d9633559b7903e21b61b845f7e1766afa74ef85e3380f41265e6b5"
 
     // original : 727be6789e8f4f6eab66288f957b58800e47a4bacebacc0dd700e8f9a374f116
-    example3    = "423dc9866d1c5f32cabfeb254030d83e11db4d807394a8ff09be47d8bfc38f18"
+    example3   = "423dc9866d1c5f32cabfeb254030d83e11db4d807394a8ff09be47d8bfc38f18"
 
   strings:
     //$lib = "libaurorabridge.so"

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -26,8 +26,6 @@
  **/
 
 
-include "../dex/common.yara"
-
 
 rule ollvm_v3_4 : obfuscator
 {
@@ -145,14 +143,18 @@ rule firehash : obfuscator
   meta:
     description = "Firehash (VM-based)"
     url         = "https://firehash.grayhash.com/"
-    example     = "38e2170a5f272ecae97dddb0dac0c1f39f7f71a4639477764a9154557106dd94" // https://firehash.grayhash.com/static/sample/dodocrackme_obfuscated.apk
-    example     = "bc6924eede0c59021db18235ee0b2423aed9d9e265f85f0e35946cc2724cccbe" // https://firehash.grayhash.com/static/sample/dodocrackme_original.apk
 
-    // plaintext  : 6352f6d0cdc85a42de3ccfd9226dfec28280aa835227acc507043a4403b7e700
-    // firehashed : c98af9a777d9633559b7903e21b61b845f7e1766afa74ef85e3380f41265e6b5
+    // original : https://firehash.grayhash.com/static/sample/dodocrackme_obfuscated.apk
+    example1    = "38e2170a5f272ecae97dddb0dac0c1f39f7f71a4639477764a9154557106dd94"
 
-    // plaintext  : 727be6789e8f4f6eab66288f957b58800e47a4bacebacc0dd700e8f9a374f116
-    // firehashed : 423dc9866d1c5f32cabfeb254030d83e11db4d807394a8ff09be47d8bfc38f18
+    // original : https://firehash.grayhash.com/static/sample/dodocrackme_original.apk
+    example2    = "bc6924eede0c59021db18235ee0b2423aed9d9e265f85f0e35946cc2724cccbe"
+
+    // original : 6352f6d0cdc85a42de3ccfd9226dfec28280aa835227acc507043a4403b7e700
+    example3    = "c98af9a777d9633559b7903e21b61b845f7e1766afa74ef85e3380f41265e6b5"
+
+    // original : 727be6789e8f4f6eab66288f957b58800e47a4bacebacc0dd700e8f9a374f116
+    example4    = "423dc9866d1c5f32cabfeb254030d83e11db4d807394a8ff09be47d8bfc38f18"
 
   strings:
     //$lib = "libaurorabridge.so"
@@ -170,7 +172,4 @@ rule firehash : obfuscator
   condition:
     all of them
 }
-
-
-
 

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -26,6 +26,8 @@
  **/
 
 
+import "elf"
+
 
 rule ollvm_v3_4 : obfuscator
 {
@@ -141,7 +143,7 @@ rule ollvm : obfuscator
 rule firehash : obfuscator
 {
   meta:
-    description = "Firehash (VM-based)"
+    description = "Firehash"
     url         = "https://firehash.grayhash.com/"
 
     // original   : https://firehash.grayhash.com/static/sample/dodocrackme_original.apk
@@ -168,6 +170,6 @@ rule firehash : obfuscator
     }
 
   condition:
-    all of them
+    elf.machine == elf.EM_ARM and all of them
 }
 

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -144,17 +144,15 @@ rule firehash : obfuscator
     description = "Firehash (VM-based)"
     url         = "https://firehash.grayhash.com/"
 
-    // original : https://firehash.grayhash.com/static/sample/dodocrackme_obfuscated.apk
+    // original   : https://firehash.grayhash.com/static/sample/dodocrackme_original.apk
+    // firehashed : https://firehash.grayhash.com/static/sample/dodocrackme_obfuscated.apk
     example1    = "38e2170a5f272ecae97dddb0dac0c1f39f7f71a4639477764a9154557106dd94"
 
-    // original : https://firehash.grayhash.com/static/sample/dodocrackme_original.apk
-    example2    = "bc6924eede0c59021db18235ee0b2423aed9d9e265f85f0e35946cc2724cccbe"
-
     // original : 6352f6d0cdc85a42de3ccfd9226dfec28280aa835227acc507043a4403b7e700
-    example3    = "c98af9a777d9633559b7903e21b61b845f7e1766afa74ef85e3380f41265e6b5"
+    example2    = "c98af9a777d9633559b7903e21b61b845f7e1766afa74ef85e3380f41265e6b5"
 
     // original : 727be6789e8f4f6eab66288f957b58800e47a4bacebacc0dd700e8f9a374f116
-    example4    = "423dc9866d1c5f32cabfeb254030d83e11db4d807394a8ff09be47d8bfc38f18"
+    example3    = "423dc9866d1c5f32cabfeb254030d83e11db4d807394a8ff09be47d8bfc38f18"
 
   strings:
     //$lib = "libaurorabridge.so"


### PR DESCRIPTION
Hi,

This protector creates stubs like the following:

![firehash-ida](https://user-images.githubusercontent.com/14809754/33800170-4c2b4186-dd3b-11e7-955b-af1ea8b47870.png)

Therefore, we can match it using these opcodes:
```
    $opcodes_arm = {
        04 00 2D E5  //  STR     R0, [SP,#var_4]!
        00 00 0F E1  //  MRS     R0, CPSR
        01 00 51 E1  //  CMP     R1, R1
        02 00 00 ?A  //  BNE     loc_F0854
        00 F0 29 E1  //  MSR     CPSR_cf, R0
        04 00 9D E4  //  LDR     R0, [SP+4+var_4],#4
        ?? ?? ?? EA  //  B       loc_F0828
    }
```

Opening the binary into @Radare helps us to see the huge amount of matches:

```
$ r2 libaurorabridge.so 
 -- Change the size of the file with the 'r' (resize) command
[0x000075c0]> /x 04002DE500000FE1010051E10.0000.A00F029E104009DE4......EA
Searching 28 bytes in [0x0-0x29350]
hits: 0
Searching 28 bytes in [0x2aeb0-0x48f684]
hits: 0
Searching 28 bytes in [0x48f684-0x4968d1]
hits: 0
Searching 28 bytes in [0x497684-0x4e496c]
hits: 6367
Do you want to print 6367 lines? (y/N) y
<SNIPPED>
0x004e4718 hit0_6353 04002de500000fe1010051e10200001a00f029e104009de4deffffea
0x004e4740 hit0_6354 04002de500000fe1010051e10200000a00f029e104009de41b9decea
0x004e4768 hit0_6355 04002de500000fe1010051e10200001a00f029e104009de4cdffffea
0x004e4790 hit0_6356 04002de500000fe1010051e10200001a00f029e104009de4c4ffffea
0x004e47b8 hit0_6357 04002de500000fe1010051e10200000a00f029e104009de4d2b1ecea
0x004e47e0 hit0_6358 04002de500000fe1010051e10200000a00f029e104009de490fdecea
0x004e4808 hit0_6359 04002de500000fe1010051e10200000a00f029e104009de424afecea
0x004e4830 hit0_6360 04002de500000fe1010051e10200001a00f029e104009de4a4ffffea
0x004e4858 hit0_6361 04002de500000fe1010051e10200001a00f029e104009de49cffffea
0x004e48a4 hit0_6362 04002de500000fe1010051e10200001a00f029e104009de4efffffea
0x004e48cc hit0_6363 04002de500000fe1010051e10200000a00f029e104009de48da9ecea
0x004e48f4 hit0_6364 04002de500000fe1010051e10200001a00f029e104009de4ddffffea
0x004e491c hit0_6365 04002de500000fe1010051e10200001a00f029e104009de4d4ffffea
0x004e4944 hit0_6366 04002de500000fe1010051e10200000a00f029e104009de42991ecea
[0x000075c0]> 
```

<img src="https://user-images.githubusercontent.com/14809754/33800418-a120bc30-dd3f-11e7-9095-5324862bc58f.png" width="500" height="700" >


Samples: 
```
    example     = "38e2170a5f272ecae97dddb0dac0c1f39f7f71a4639477764a9154557106dd94"
    // https://firehash.grayhash.com/static/sample/dodocrackme_obfuscated.apk

    example     = "bc6924eede0c59021db18235ee0b2423aed9d9e265f85f0e35946cc2724cccbe"
    // https://firehash.grayhash.com/static/sample/dodocrackme_original.apk

    // plaintext  : 6352f6d0cdc85a42de3ccfd9226dfec28280aa835227acc507043a4403b7e700
    // firehashed : c98af9a777d9633559b7903e21b61b845f7e1766afa74ef85e3380f41265e6b5

    // plaintext  : 727be6789e8f4f6eab66288f957b58800e47a4bacebacc0dd700e8f9a374f116
    // firehashed : 423dc9866d1c5f32cabfeb254030d83e11db4d807394a8ff09be47d8bfc38f18
```