### PR TITLE
Arxn multidex

### DIFF
--- a/apkid/rules/dex/obfuscators.yara
+++ b/apkid/rules/dex/obfuscators.yara
@@ -121,7 +121,7 @@ rule arxan : obfuscator
   strings:
     // Obfuscated Lpackage/class/: "L([a-z]\1{5}\/[a-z]{6}\/".
     // AFAIK, Yara does not support backreferences at the moment, thus this is the combo:
-	$pkg = /L(a{6}|b{6}|c{6}|d{6}|e{6}|f{6}|g{6}|h{6}|i{6}|j{6}|k{6}|l{6}|m{6}|n{6}|o{6}|p{6}|q{6}|r{6}|s{6}|t{6}|u{6}|v{6}|w{6}|x{6}|y{6}|z{6})\/[a-z]{6}/
+    $pkg = /L(a{6}|b{6}|c{6}|d{6}|e{6}|f{6}|g{6}|h{6}|i{6}|j{6}|k{6}|l{6}|m{6}|n{6}|o{6}|p{6}|q{6}|r{6}|s{6}|t{6}|u{6}|v{6}|w{6}|x{6}|y{6}|z{6})\/[a-z]{6}/
 
     // Obfuscated methods are found to follow a pattern like:
     // 1 byte size + 1 byte ASCII + [7-26] non-ASCII bytes + 00 (null terminator)
@@ -138,5 +138,7 @@ rule arxan : obfuscator
     $pkg and
     6 of ($m*)
 }
+
+
 
 

--- a/apkid/rules/dex/obfuscators.yara
+++ b/apkid/rules/dex/obfuscators.yara
@@ -140,5 +140,37 @@ rule arxan : obfuscator
 }
 
 
+rule arxan_multidex : obfuscator
+{
+  meta:
+    description = "Arxan (multidex)"
+    url         = "https://www.arxan.com/products/application-protection-mobile/"
+    example     = "9b2a978a937293d6cb93439e0f819b4e044a3fad80dde92dec9b67e419278b5d"
+
+  strings:
+    // Obfuscated Lpackage/class/: "L([a-z]\1{5}\/[a-z]{6}\/".
+    // AFAIK, Yara does not support backreferences at the moment, thus this is the combo:
+    $pkg = /L(a{6}|b{6}|c{6}|d{6}|e{6}|f{6}|g{6}|h{6}|i{6}|j{6}|k{6}|l{6}|m{6}|n{6}|o{6}|p{6}|q{6}|r{6}|s{6}|t{6}|u{6}|v{6}|w{6}|x{6}|y{6}|z{6})\/[a-z]{6}/
+
+    // Obfuscated methods are found to follow a pattern like:
+    // 1 byte size + 1 byte ASCII + [7-26] non-ASCII bytes + 00 (null terminator)
+    $m1 = { 10 62 (6? | 75) [14] 00 }
+    $m2 = { (0b | 0d) 62 d0 [15] 00 }
+    $m3 = { (0e | 10) 62 30 34 3? [15] 00 }
+    $m4 = { (0b | 0d) 62 30 34 3? [13] 00 }
+    $m5 = { (08 | 0b | 0d | 0e ) 62 [7-13] 00 }
+    $m6 = { 0a 62 (30 34 3? | d? ?? ??) [11] 00 }
+    $m7 = { (0d | 0b | 11) (62 d1 8? | 6? ?? ??) [14] 00 }
+
+  condition:
+    is_dex and
+    $pkg and
+    2 of ($m*) and
+    not arxan
+}
+
+
+
+
 
 

--- a/apkid/rules/dex/obfuscators.yara
+++ b/apkid/rules/dex/obfuscators.yara
@@ -170,7 +170,3 @@ rule arxan_multidex : obfuscator
 }
 
 
-
-
-
-


### PR DESCRIPTION
Hitting some samples that before with the aggressive rule weren't.

```
apkid com.exampleandroid.apk
[+] APKiD 1.0.0 :: from RedNaga :: rednaga.io
[*] com.exampleandroid.apk!classes2.dex
 |-> anti_vm : Build.FINGERPRINT check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, SIM operator check, network operator name check
 |-> compiler : dx
 |-> obfuscator : Arxan (multidex)
[*] com.exampleandroid.apk!classes.dex
 |-> anti_vm : Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, SIM operator check, network operator name check
 |-> compiler : dx
[*] com.exampleandroid.apk!classes3.dex
 |-> anti_debug : Debug.isDebuggerConnected() check
 |-> anti_vm : Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, network operator name check
 |-> compiler : dx
 |-> obfuscator : Arxan (multidex)
```
