### PR TITLE
AVDobfuscator (seen in secneo/bangle)

### DIFF
--- a/apkid/rules/elf/common.yara
+++ b/apkid/rules/elf/common.yara
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018  RedNaga. https://rednaga.io
+ * All rights reserved. Contact: rednaga@protonmail.com
+ *
+ *
+ * This file is part of APKiD
+ *
+ *
+ * Commercial License Usage
+ * ------------------------
+ * Licensees holding valid commercial APKiD licenses may use this file
+ * in accordance with the commercial license agreement provided with the
+ * Software or, alternatively, in accordance with the terms contained in
+ * a written agreement between you and RedNaga.
+ *
+ *
+ * GNU General Public License Usage
+ * --------------------------------
+ * Alternatively, this file may be used under the terms of the GNU General
+ * Public License version 3.0 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.GPL included in the packaging of this
+ * file. Please visit http://www.gnu.org/copyleft/gpl.html and review the
+ * information to ensure the GNU General Public License version 3.0
+ * requirements will be met.
+ *
+ **/
+
+private rule is_elf
+{
+    meta:
+        description = "Identifies an ELF binary based on its magic number"
+        author      = "Eduardo Novella"
+
+    strings:
+        $elf_magic = { 7F 45 4C 46 }
+
+    condition:
+       $elf_magic at 0
+}

--- a/apkid/rules/elf/common.yara
+++ b/apkid/rules/elf/common.yara
@@ -34,6 +34,5 @@ private rule is_elf
         author      = "Eduardo Novella"
 
     condition:
-       //$elf_magic at 0
        elf.number_of_sections >= 0
 }

--- a/apkid/rules/elf/common.yara
+++ b/apkid/rules/elf/common.yara
@@ -25,15 +25,15 @@
  *
  **/
 
+import "elf"
+
 private rule is_elf
 {
     meta:
         description = "Identifies an ELF binary based on its magic number"
         author      = "Eduardo Novella"
 
-    strings:
-        $elf_magic = { 7F 45 4C 46 }
-
     condition:
-       $elf_magic at 0
+       //$elf_magic at 0
+       elf.number_of_sections >= 0
 }

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017  RedNaga. http://rednaga.io
+ * Copyright (C) 2018  RedNaga. https://rednaga.io
  * All rights reserved. Contact: rednaga@protonmail.com
  *
  *
@@ -27,6 +27,7 @@
 
 
 import "elf"
+include "common.yara"
 
 
 rule ollvm_v3_4 : obfuscator
@@ -35,6 +36,7 @@ rule ollvm_v3_4 : obfuscator
     description = "Obfuscator-LLVM version 3.4"
     url         = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = "cd16ad33bf203dbaa9add803a7a0740e3727e8e60c316d33206230ae5b985f25"
+    author      = "Eduardo Novella"
 
   strings:
     // "Obfuscator-clang version 3.4 (tags/RELEASE_34/final) (based on LLVM 3.4svn)"
@@ -52,6 +54,7 @@ rule ollvm_v3_5 : obfuscator
     description = "Obfuscator-LLVM version 3.5"
     url         = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = "664214969f1b94494a8fc0491407f4440032fc5c922eb0664293d0440c52dbe7"
+    author      = "Eduardo Novella"
 
   strings:
     // "Obfuscator- clang version 3.5.0 (tags/RELEASE_350/final) (based on LLVM 3.5.0svn)"
@@ -69,6 +72,7 @@ rule ollvm_v3_6_1 : obfuscator
     description = "Obfuscator-LLVM version 3.6.1"
     url         = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = "d84b45856b5c95f7a6e96ab0461648f22ad29d1c34a8e85588dad3d89f829208"
+    author      = "Eduardo Novella"
 
   strings:
     // "Obfuscator-LLVM clang version 3.6.1 (tags/RELEASE_361/final) (based on Obfuscator-LLVM 3.6.1)"
@@ -86,6 +90,7 @@ rule ollvm_v4_0 : obfuscator
     description = "Obfuscator-LLVM version 4.0"
     url         = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = "aaba570388d0fe25df45480ecf894625be7affefaba24695d8c1528b974c00df"
+    author      = "Eduardo Novella"
 
   strings:
     // "Obfuscator-LLVM clang version 4.0.1  (based on Obfuscator-LLVM 4.0.1)"
@@ -103,6 +108,7 @@ rule ollvm_v6_0_strenc : obfuscator
     description = "Obfuscator-LLVM version 6.0 (string encryption)"
     url         = "https://github.com/obfuscator-llvm/obfuscator/wiki"
     example     = "f3a2e6c57def9a8b4730965dd66ca0f243689153139758c44718b8c5ef9c1d17"
+    author      = "Eduardo Novella"
 
   strings:
     // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0)"
@@ -121,6 +127,7 @@ rule ollvm_v6_0 : obfuscator
   meta:
     description = "Obfuscator-LLVM version 6.0"
     url         = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    author      = "Eduardo Novella"
 
   strings:
     // "Obfuscator-LLVM clang version 6.0.0 (trunk) (based on Obfuscator-LLVM 6.0.0)"
@@ -138,6 +145,7 @@ rule ollvm : obfuscator
   meta:
     description = "Obfuscator-LLVM version unknown"
     url         = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    author      = "Eduardo Novella"
 
   strings:
     $ollvm1 = "Obfuscator-LLVM "
@@ -160,6 +168,7 @@ rule firehash : obfuscator
   meta:
     description = "Firehash"
     url         = "https://firehash.grayhash.com/"
+    author      = "Eduardo Novella"
 
     // original   : https://firehash.grayhash.com/static/sample/dodocrackme_original.apk
     // firehashed : https://firehash.grayhash.com/static/sample/dodocrackme_obfuscated.apk
@@ -187,3 +196,24 @@ rule firehash : obfuscator
   condition:
     elf.machine == elf.EM_ARM and all of them
 }
+
+rule avdobfuscator : obfuscator
+{
+  meta:
+    description = "AVDobfuscator"
+    url         = "https://github.com/andrivet/ADVobfuscator"
+    author      = "Eduardo Novella"
+    example     = "357f0c2ad6bf5cf60c671b090eab134251db63993f52aef512bde5bfa4a1b598 "
+
+  strings:
+    $o1 = "ObfuscatedAddress"
+    $o2 = "ObfuscatedCall"
+    $o3 = "ObfuscatedCallP"
+    $o4 = "ObfuscatedCallRet"
+    $o5 = "ObfuscatedCallRetP"
+    $o6 = "ObfuscatedFunc"
+
+  condition:
+    1 of ($o*) and is_elf
+}
+

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -206,14 +206,20 @@ rule avdobfuscator : obfuscator
     example     = "357f0c2ad6bf5cf60c671b090eab134251db63993f52aef512bde5bfa4a1b598"
 
   strings:
-    $o1 = "ObfuscatedAddress"
-    $o2 = "ObfuscatedCall"
-    $o3 = "ObfuscatedCallP"
-    $o4 = "ObfuscatedCallRet"
-    $o5 = "ObfuscatedCallRetP"
-    $o6 = "ObfuscatedFunc"
+    $s_01 = "_ZNK17ObfuscatedAddressIPFiiiPciS0_S0_EE8originalEv"
+    $s_02 = "_ZNK17ObfuscatedAddressIPFiPcEE8originalEv"
+    $s_03 = "_ZNK17ObfuscatedAddressIPFvPciEE8originalEv"
+    $s_04 = "_ZNK17ObfuscatedAddressIPFvPcS0_EE8originalEv"
+    $s_05 = "_ZNK17ObfuscatedAddressIPFvvEE8originalEv"
+    $s_06 = "_Z14ObfuscatedCallI17ObfuscatedAddressIPFvvEEJEEvT_DpOT0_"
+    $s_07 = "_ZNK17ObfuscatedAddressIPFiPviEE8originalEv"
+    $s_08 = "_ZNK17ObfuscatedAddressIPFvPcEE8originalEv"
+    $s_09 = "_ZNK17ObfuscatedAddressIPFvP7_JNIEnvEE8originalEv"
+    $s_10 = "_ZNK17ObfuscatedAddressIPFvPcS0_iiEE8originalEv"
+    $s_11 = "_ZNK17ObfuscatedAddressIPFvcEE8originalEv"
+    $s_12 = "_ZNK17ObfuscatedAddressIPFvPviiEE8originalEv"
 
   condition:
-    1 of ($o*) and is_elf
+    any of them and is_elf
 }
 

--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -203,7 +203,7 @@ rule avdobfuscator : obfuscator
     description = "AVDobfuscator"
     url         = "https://github.com/andrivet/ADVobfuscator"
     author      = "Eduardo Novella"
-    example     = "357f0c2ad6bf5cf60c671b090eab134251db63993f52aef512bde5bfa4a1b598 "
+    example     = "357f0c2ad6bf5cf60c671b090eab134251db63993f52aef512bde5bfa4a1b598"
 
   strings:
     $o1 = "ObfuscatedAddress"


### PR DESCRIPTION
Because @strazzere is lazy :+1:  and the secneo research has been released.

Further info at: https://github.com/rednaga/APKiD/issues/80

## **Changes:**
- Update year and  rednaga https
- Update author on OLLVM rules
- Create file elf/common.yara to have is_elf
- AVDobfuscator rule done and tested

## **Samples:**
https://koodous.com/rulesets/4200/apks