### PR TITLE
Add rule for AppGuard TOAST-NHNent

### DIFF
--- a/apkid/rules/apk/packers.yara
+++ b/apkid/rules/apk/packers.yara
@@ -69,7 +69,7 @@ rule appguard_b : packer
     samples     = "https://koodous.com/rulesets/5249/apks"
     author      = "Eduardo Novella"
 
-	strings:
+  strings:
     // package com.nhnent.appguard;
     $a1 = "assets/classes.jet"
     $a2 = "assets/classes.zip"

--- a/apkid/rules/apk/packers.yara
+++ b/apkid/rules/apk/packers.yara
@@ -41,7 +41,7 @@ rule appguard : packer
     is_apk and ($stub and $encrypted_dex)
 }
 
-rule appguard_new : packer
+rule appguard_a : packer
 {
   meta:
     description = "AppGuard"
@@ -57,6 +57,37 @@ rule appguard_new : packer
 
   condition:
     is_apk and 3 of them
+}
+
+rule appguard_b : packer
+{
+  meta:
+    description = "AppGuard (TOAST-NHNent)"
+    url         = "https://docs.toast.com/en/Security/AppGuard/en/Overview/"
+    url2        = "https://www.toast.com/service/security/appguard"
+    sample      = "80ac3e9d3b36613fa82085cf0f5d03b58ce20b72ba29e07f7c744df476aa9a92"
+    samples     = "https://koodous.com/rulesets/5249/apks"
+    author      = "Eduardo Novella"
+
+	strings:
+    // package com.nhnent.appguard;
+    $a1 = "assets/classes.jet"
+    $a2 = "assets/classes.zip"
+    $a3 = "assets/classes2.jet"
+    $a4 = "assets/classes2.zip"
+    $a5 = "assets/classes3.jet"
+    $a6 = "assets/classes3.zip"
+    $b1 = "lib/armeabi-v7a/libloader.so"
+    $b2 = "lib/x86/libloader.so"
+    $b3 = "lib/armeabi-v7a/libdiresu.so"
+    $b4 = "lib/x86/libdiresu.so"
+    $c1 = "assets/m7a"
+    $c2 = "assets/m8a"
+    $c3 = "assets/agconfig"    //appguard cfg?
+    $c4 = "assets/agmetainfo"
+
+  condition:
+    is_apk and (2 of ($a*) and 1 of ($b*) and 1 of ($c*))
 }
 
 rule dxshield : packer
@@ -618,9 +649,9 @@ rule tencent_legu : packer
     $b = "assets/0OO00l111l1l"
     $c = "assets/0OO00oo01l1l"
     $d = "assets/o0oooOO0ooOo.dat"
- 
+
   condition:
     is_apk
-    and $b 
+    and $b
     and ($a or $c or $d)
 }


### PR DESCRIPTION
More samples at https://koodous.com/rulesets/5249/apks

```sh
[22:13 edu@xps appguard_toast] >  apkid .
[+] APKiD 2.1.0 :: from RedNaga :: rednaga.io
[*] ./8e111e5fde94f945cc7457c812e91d92659145afcf81769c2338c2b2fce902d3
 |-> packer : AppGuard (TOAST-NHNent)
[*] ./8e111e5fde94f945cc7457c812e91d92659145afcf81769c2338c2b2fce902d3!assets/nni_classes.zip!classes.dex
 |-> compiler : dx
[*] ./8e111e5fde94f945cc7457c812e91d92659145afcf81769c2338c2b2fce902d3!classes.dex
 |-> compiler : dx
[*] ./c084717cfec865f6dfc1892c0f66c6a40c508e8b7b75ac9d03e4de1e47ac391b
 |-> packer : AppGuard (TOAST-NHNent)
[*] ./c084717cfec865f6dfc1892c0f66c6a40c508e8b7b75ac9d03e4de1e47ac391b!classes.dex
 |-> compiler : dexlib 2.x
[*] ./com.nhnpixelcube.fishislandII.apk
 |-> packer : AppGuard (TOAST-NHNent)
[*] ./com.nhnpixelcube.fishislandII.apk!classes.dex
 |-> compiler : dexlib 2.x
[*] ./b22fa1514f1170370bc80baf7d9186137ad5b5ec53ce1471dfbab6fb76bff5e4
 |-> packer : AppGuard (TOAST-NHNent)
[*] ./b22fa1514f1170370bc80baf7d9186137ad5b5ec53ce1471dfbab6fb76bff5e4!assets/vivounionsdk/vivounionapk_v2.2.41_a1e788e_201708101947.vua!classes.dex
 |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, SIM operator check, device ID check, emulator file check, network operator name check, possible Build.SERIAL check, ro.kernel.qemu check, ro.product.device check, subscriber ID check
 |-> compiler : dx
[*] ./b22fa1514f1170370bc80baf7d9186137ad5b5ec53ce1471dfbab6fb76bff5e4!classes.dex
 |-> compiler : dexlib 2.x
[*] ./com.nhnpixelcube.fishislandII_2019-01-09.apk
 |-> packer : AppGuard (TOAST-NHNent)
[*] ./com.nhnpixelcube.fishislandII_2019-01-09.apk!classes.dex
 |-> compiler : dexlib 2.x
 |-> obfuscator : unreadable field names, unreadable method names
```