### PR TITLE
Obfuscapk - LibEncryption plugin  Closes #158 

### DIFF
--- a/apkid/rules/apk/obfuscators.yara
+++ b/apkid/rules/apk/obfuscators.yara
@@ -63,3 +63,19 @@ rule gemalto_protector : obfuscator
   condition:
     any of them and is_apk
 }
+
+rule obfuscapk_libencryption : obfuscator
+{
+  meta:
+    description = "Obfuscapk - LibEncryption plugin"
+    url         = "https://github.com/ClaudiuGeorgiu/Obfuscapk"
+    author      = "packmad - https://twitter.com/packm4d"
+    sample      = "4957d9c1b423ae045f27d97b1d0b1f32ba6a2ce56525a2e93bda7172ec18ad0c"
+
+  strings:
+    $lib_arm = /assets\/lib\.arm(eabi|64)-v[0-9a-zA-Z]{2}\.[!-~]+\.so/
+    $lib_x86 = /assets\/lib\.x86(_64)?\.[!-~]+\.so/
+
+  condition:
+    any of them and is_apk
+}


### PR DESCRIPTION
Given the fact that Yara is [very limited](https://github.com/VirusTotal/yara/issues/1145) when it comes to Android, I have created the only reliable rule to detect a plugin of Obfuscapk.

Unfortunately, I don't have access to VT hunting, but I have posted [the rule on Koodous](https://koodous.com/my_rulesets/6277).