### PR TITLE
Add new Promon packer rule

### DIFF
--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -361,11 +361,11 @@ rule promon : packer
     */
 
   condition:
-    is_elf and
-    (($libshield and $b and $c and $d) or ($rnd_libname and $b and $c and $d)) and
-    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) or
-    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) or
-    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)
+    is_elf and $b and $c and $d and
+    ($libshield or $rnd_libname) and
+    (for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) or
+     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) or
+     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/))
 }
 
 rule appsealing_core_2_10_10 : packer

--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -334,47 +334,35 @@ rule upx_unknown_version_unmodified : packer
     not upx_compressed_apk
 }
 
-rule promon_a : packer
+rule promon : packer
 {
   meta:
     description = "Promon Shield"
     url         = "https://promon.co/"
     sample      = "6a3352f54d9f5199e4bf39687224e58df642d1d91f1d32b069acd4394a0c4fe0"
+    sample2     = "0ef06e0b1511872e711cf3e8e53fee097d13755c9572cfea6d153d708906f45d"
     author      = "Eduardo Novella"
 
   strings:
-    $a = "libshield.so"
+    // Library names
+    $libshield = "libshield.so"
+    $rnd_libname = /lib[a-z]{10,12}\.so/ // libchhjkikihfch.so || libgiompappkhnb.so
+
+    // Symbols
     $b = "deflate"
     $c = "inflateInit2"
     $d = "crc32"
 
-    // Odd ELF segments found:
-    // .ncc -> Code segment
-    // .ncd -> Data segment
-    // .ncu -> Another segment
-
-  condition:
-    all of them and
-    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) or
-    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) or
-    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)
-}
-
-rule promon_b : packer
-{
-  meta:
-    description = "Promon Shield"
-    url         = "https://promon.co/"
-    sample      = "0ef06e0b1511872e711cf3e8e53fee097d13755c9572cfea6d153d708906f45d"
-    author      = "Eduardo Novella"
-
-  strings:
-    // libchhjkikihfch.so || libgiompappkhnb.so
-    $rnd_libname = /lib[a-z]{10,12}\.so/
+    /**
+     Odd ELF segments found:
+      .ncc -> Code segment
+      .ncd -> Data segment
+      .ncu -> Another segment
+    */
 
   condition:
     is_elf and
-    $rnd_libname and
+    (($libshield and $b and $c and $d) or ($rnd_libname and $b and $c and $d)) and
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) or
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) or
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)

--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -363,9 +363,14 @@ rule promon : packer
   condition:
     is_elf and $b and $c and $d and
     ($libshield or $rnd_libname) and
-    (for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) or
-     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) or
-     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/))
+    (   // Match at least two section names from .ncu, .ncc, .ncd
+        (for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/)
+            and for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/))  or
+        (for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/)
+            and for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/))  or
+        (for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/)
+            and for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/))
+    )
 }
 
 rule appsealing_core_2_10_10 : packer

--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -348,13 +348,16 @@ rule promon_a : packer
     $c = "inflateInit2"
     $d = "crc32"
 
-    $s1 = /.ncc/  // Code segment
-    $s2 = /.ncd/  // Data segment
-    $s3 = /.ncu/  // Another segment
+    // Odd ELF segments found:
+    // .ncc -> Code segment
+    // .ncd -> Data segment
+    // .ncu -> Another segment
 
   condition:
     ($a and $b and $c and $d) and
-    2 of ($s*)
+    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) and
+    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) and
+    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)
 }
 
 rule promon_b : packer

--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -355,9 +355,8 @@ rule promon_a : packer
 
   condition:
     all of them and
-    // TODO match 2 out 3 ELF segments
-    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) and
-    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) and
+    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) or
+    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) or
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)
 }
 
@@ -376,9 +375,8 @@ rule promon_b : packer
   condition:
     is_elf and
     $rnd_libname and
-    not promon_a and
-    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) and
-    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) and
+    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) or
+    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) or
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)
 }
 

--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -334,7 +334,7 @@ rule upx_unknown_version_unmodified : packer
     not upx_compressed_apk
 }
 
-rule promon : packer
+rule promon_a : packer
 {
   meta:
     description = "Promon Shield"
@@ -357,7 +357,7 @@ rule promon : packer
     2 of ($s*)
 }
 
-rule promon_a : packer
+rule promon_b : packer
 {
   meta:
     description = "Promon Shield"
@@ -372,6 +372,7 @@ rule promon_a : packer
   condition:
     is_elf and
     $rnd_libname and
+    not promon_b and
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) and
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) and
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)

--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -372,7 +372,7 @@ rule promon_b : packer
   condition:
     is_elf and
     $rnd_libname and
-    not promon_b and
+    not promon_a and
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) and
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) and
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)

--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -340,6 +340,7 @@ rule promon : packer
     description = "Promon Shield"
     url         = "https://promon.co/"
     sample      = "6a3352f54d9f5199e4bf39687224e58df642d1d91f1d32b069acd4394a0c4fe0"
+    author      = "Eduardo Novella"
 
   strings:
     $a = "libshield.so"
@@ -354,6 +355,26 @@ rule promon : packer
   condition:
     ($a and $b and $c and $d) and
     2 of ($s*)
+}
+
+rule promon_a : packer
+{
+  meta:
+    description = "Promon Shield"
+    url         = "https://promon.co/"
+    sample      = "0ef06e0b1511872e711cf3e8e53fee097d13755c9572cfea6d153d708906f45d"
+    author      = "Eduardo Novella"
+
+  strings:
+    // libchhjkikihfch.so || libgiompappkhnb.so
+    $rnd_libname = /lib[a-z]{10,12}\.so/
+
+  condition:
+    is_elf and
+    $rnd_libname and
+    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) and
+    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) and
+    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)
 }
 
 rule appsealing_core_2_10_10 : packer

--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -345,7 +345,7 @@ rule promon : packer
 
   strings:
     // Library names
-    $libshield = "libshield.so"
+    $libshield   = "libshield.so"
     $rnd_libname = /lib[a-z]{10,12}\.so/ // libchhjkikihfch.so || libgiompappkhnb.so
 
     // Symbols

--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -354,7 +354,8 @@ rule promon_a : packer
     // .ncu -> Another segment
 
   condition:
-    ($a and $b and $c and $d) and
+    all of them and
+    // TODO match 2 out 3 ELF segments
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) and
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) and
     for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)


### PR DESCRIPTION
This condition could be improved:
```sh
  condition:
    is_elf and
    $rnd_libname and
    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/) and
    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/) and
    for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)
```

By only matching 2 out of 3 section names:
```sh
  condition:
    is_elf and
    $rnd_libname and 2 of (
        for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncu/)
        for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncc/),
        for any i in (0..elf.number_of_sections): (elf.sections[i].name matches /\.ncd/)
  )
```

Any thoughts? The above syntax doesn't compile.

```sh
[14:08 edu@xps tmp] >  apkid promon.apk 
[+] APKiD 2.1.0 :: from RedNaga :: rednaga.io
[*] promon.apk!classes2.dex
 |-> anti_debug : Debug.isDebuggerConnected() check
 |-> anti_vm : Build.MODEL check, Build.PRODUCT check, Build.TAGS check, possible VM check
 |-> compiler : dexlib 2.x
[*] promon.apk!classes3.dex
 |-> compiler : dexlib 2.x
[*] promon.apk!classes.dex
 |-> anti_vm : possible Build.SERIAL check, possible VM check
 |-> compiler : dexlib 2.x
[*] promon.apk!classes4.dex
 |-> compiler : dexlib 2.x
[*] promon.apk!lib/x86/libchhjkikihfch.so
 |-> obfuscator : Obfuscator-LLVM version 3.5
 |-> packer : Promon Shield
[*] promon.apk!lib/armeabi-v7a/libchhjkikihfch.so
 |-> obfuscator : Obfuscator-LLVM version 3.5
 |-> packer : Promon Shield
[*] promon.apk!lib/x86_64/libchhjkikihfch.so
 |-> obfuscator : Obfuscator-LLVM version 3.5
 |-> packer : Promon Shield
[*] promon.apk!lib/arm64-v8a/libchhjkikihfch.so
 |-> obfuscator : Obfuscator-LLVM version 3.5
 |-> packer : Promon Shield
```