### PR TITLE
Fix #242, errors should go to stderr to avoid JSON crashes

### DIFF
--- a/apkid/apkid.py
+++ b/apkid/apkid.py
@@ -26,6 +26,7 @@
 
 import io
 import os
+import sys
 import traceback
 import zipfile
 from typing import Union, IO, List, Dict, Set
@@ -155,7 +156,8 @@ class Scanner(object):
                 self._scan_zip_entry(zf, info, results, depth)
             except Exception as e:
                 stack = traceback.format_exc()
-                print(f"Exception scanning {info.filename} in {zf.filename}, depth={depth}: {stack}")
+                print(f"Exception scanning {info.filename} in {zf.filename}, depth={depth}: {stack}",
+                    file=sys.stderr)
         return results
 
     def _scan_zip_entry(self, zf, info, results, depth) -> None:


### PR DESCRIPTION
Issue found when parsing the JSON output from APKID. This spits out the errors to stdout so later JSON parsing crashes.

# Fix
```sh
[16:47 edu@xps APKiD]  (master)>  apkid -j /tmp/apkid-crash.apk 2>/dev/null
{"apkid_version": "2.1.1", "files": [{"filename": "/tmp/apkid-crash.apk!classes.dex", "matches": {"anti_vm": ["Build.FINGERPRINT check", "Build.MANUFACTURER check", "Build.HARDWARE check", "Build.BOARD check", "Build.TAGS check", "network operator name check"], "compiler": ["r8"]}}, {"filename": "/tmp/apkid-crash.apk!classes2.dex", "matches": {"anti_debug": ["Debug.isDebuggerConnected() check"], "anti_vm": ["Build.FINGERPRINT check", "Build.MODEL check", "Build.MANUFACTURER check", "Build.PRODUCT check", "possible Build.SERIAL check", "Build.TAGS check", "SIM operator check", "device ID check", "subscriber ID check", "possible VM check"], "compiler": ["r8 without marker (suspicious)"], "obfuscator": ["unreadable field names", "unreadable method names"]}}, {"filename": "/tmp/apkid-crash.apk!res/raw/android_wear_micro_apk.apk!classes.dex", "matches": {"anti_vm": ["Build.MANUFACTURER check"], "compiler": ["unknown (please file detection issue!)"]}}], "rules_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
```


# No fix
```sh
[16:38 edu@xps tmp] >  apkid -j /tmp/apkid-crash.apk 2>/dev/null
Exception scanning validasResources/myJson.zip in None, depth=1: Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/apkid-2.1.1-py3.6.egg/apkid/apkid.py", line 155, in _scan_zip
    self._scan_zip_entry(zf, info, results, depth)
  File "/usr/local/lib/python3.6/dist-packages/apkid-2.1.1-py3.6.egg/apkid/apkid.py", line 162, in _scan_zip_entry
    with zf.open(info) as entry:
  File "/usr/lib/python3.6/zipfile.py", line 1429, in open
    "required for extraction" % name)
RuntimeError: File <ZipInfo filename='validasResources/myJson.zip' filemode='-rw-rw-r--' file_size=11520 compress_size=11532> is encrypted, password required for extraction

Exception scanning validasResources/myResources.zip in None, depth=1: Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/apkid-2.1.1-py3.6.egg/apkid/apkid.py", line 155, in _scan_zip
    self._scan_zip_entry(zf, info, results, depth)
  File "/usr/local/lib/python3.6/dist-packages/apkid-2.1.1-py3.6.egg/apkid/apkid.py", line 162, in _scan_zip_entry
    with zf.open(info) as entry:
  File "/usr/lib/python3.6/zipfile.py", line 1429, in open
    "required for extraction" % name)
RuntimeError: File <ZipInfo filename='validasResources/myResources.zip' filemode='-rw-r--r--' file_size=385604 compress_size=385616> is encrypted, password required for extraction

{"apkid_version": "2.1.1", "files": [{"filename": "/tmp/apkid-crash.apk!classes.dex", "matches": {"anti_vm": ["Build.FINGERPRINT check", "Build.MANUFACTURER check", "Build.HARDWARE check", "Build.BOARD check", "Build.TAGS check", "network operator name check"], "compiler": ["r8"]}}, {"filename": "/tmp/apkid-crash.apk!classes2.dex", "matches": {"anti_debug": ["Debug.isDebuggerConnected() check"], "anti_vm": ["Build.FINGERPRINT check", "Build.MODEL check", "Build.MANUFACTURER check", "Build.PRODUCT check", "possible Build.SERIAL check", "Build.TAGS check", "SIM operator check", "device ID check", "subscriber ID check", "possible VM check"], "compiler": ["r8 without marker (suspicious)"], "obfuscator": ["unreadable field names", "unreadable method names"]}}, {"filename": "/tmp/apkid-crash.apk!res/raw/android_wear_micro_apk.apk!classes.dex", "matches": {"anti_vm": ["Build.MANUFACTURER check"], "compiler": ["unknown (please file detection issue!)"]}}], "rules_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
```