### PR TITLE
Use yara-python-dex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def package_files(directory):
 
 
 install_requires = [
-    'yara-python==3.11.0',
+    'yara-python-dex>=1.0.0',
 ]
 
 dev_requires = [


### PR DESCRIPTION
Address issue: https://github.com/rednaga/APKiD/issues/246
Wide range of wheels covers most platforms -  https://pypi.org/project/yara-python-dex/#files
Automated builds: https://github.com/MobSF/yara-python-dex/actions/runs/502757692

With this change, most people can install apkid with just `pip install apkid`