### PR TITLE
Update packers.yara to add Jiagu ELF Packer 

### DIFF
--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -640,3 +640,24 @@ rule crackproof_a : packer
   condition:
     is_elf and $init_proc and $do_asm_syscall and 1 of ($func*)
 }
+
+rule jiagu : packer
+{
+  meta:
+    description = "Jiagu"
+    sample      = "3e83c34f496bd33457ca0a100c90ed229e2c1a9e39fdcaf5670d32455c5d051e"
+    url         = "http://jiagu.360.cn/"
+    author      = "Govind Sharma"
+
+  strings:
+    $a = "libz.so"
+    $b = "uncompress"
+    $c = "libjiagu"
+    $d = "JIAGU_APP_NAME"
+    $e = "JIAGU_SO_BASE_NAME"
+    $f = "JIAGU_ENCRYPTED_DEX_NAME"
+    $g = "JIAGU_HASH_FILE_NAME"   
+
+  condition:
+    is_elf and ($a and $b and $c) and any of ($d, $e, $f, $g)
+}

--- a/apkid/rules/elf/packers.yara
+++ b/apkid/rules/elf/packers.yara
@@ -641,7 +641,7 @@ rule crackproof_a : packer
     is_elf and $init_proc and $do_asm_syscall and 1 of ($func*)
 }
 
-rule jiagu : packer
+rule jiagu_elf : packer
 {
   meta:
     description = "Jiagu"


### PR DESCRIPTION
Based On This Sample - 
[myappn.apk.zip](https://github.com/rednaga/APKiD/files/8447876/myappn.apk.zip)


Choosed libz.so and uncompress as a detection because of reason that libjiagu.so unpack a 2nd stage elf with decompressing data with uncompress method of libz.so

other 4 string are always present in all of libjiagu.so , libjiagu_a64.so, libjiagu_x64.so, libjiagu_x86.so . so presence of any 1 of them will be good to detect .