### PR TITLE
Implement detection for "MultiDex Packer"

### DIFF
--- a/apkid/rules/dex/packers.yara
+++ b/apkid/rules/dex/packers.yara
@@ -389,54 +389,54 @@ rule crazy_dog_wrapper : packer
 
 rule jsonpacker : packer
 {
-   meta:
-     description = "JsonPacker"
-     sample      = "e23f0a124fdaba30c07a3c40011dd99240af081cec4cdfcb990c811126867e59"
-     author      = "Axelle Apvrille"
+  meta:
+    description = "JsonPacker"
+    sample      = "e23f0a124fdaba30c07a3c40011dd99240af081cec4cdfcb990c811126867e59"
+    author      = "Axelle Apvrille"
 
-   strings:
-     /* typical XOR algo with junk operations */
-     $algo = {
-       b0 9b		// add-int/2addr       v11, v9
-       da 0? 0? 00 	// mul-int/lit8        v12, v11, 0
-       b3 9c 		// div-int/2addr       v12, v9
-       b0 1c 		// add-int/2addr       v12, v1
-       b0 5c		// add-int/2addr       v12, v5
-       93 0? 0? 0?	// div-int             v5, v6, v6
-       d8 0? 0? ff 	// add-int/lit8        v5, v5, -1
-       b0 5c 		// add-int/2addr       v12, v5
-       b4 66 		// rem-int/2addr       v6, v6
-       b0 6c 		// add-int/2addr       v12, v6
-       97 05 0c 0a 	// xor-int             v5, v12, v10
-     }
-     $algo2 = {
-       b0 ??					// add-int/2addr       v4, v12
-       da 0? 0? 00 				// mul-int/lit8        v4, v4, 0
-       b0 ?? 	 				// add-int/2addr       v4, v9
-       93 0? 0? 0?				// div-int             v9, v12, v12
-       (b3 69 | db 04 04 01) 	 	// div-int/2addr       v9, v6
-       	      	      	 		   		// or  div-int/lit8        v4, v4, 0x1
-       (b7 69 | df 04 04 01) 		// xor-int/2addr       v9, v6
-       	      	      	 		   		// or xor-int/lit8        v4, v4, 0x1
-       b0 ??					// add-int/2addr       v4, v9
-       94 0? 0? 0?				// rem-int             v9, v12, v12
-       b0 ?? 	 				// add-int/2addr       v4, v9
-       (b7 b4 | 97 04 07 09 ) 		// xor-int/2addr       v4, v11
-       	      	      	      		   		// or xor-int             v4, v7, v9
-     }
-     $algo3 = {
-       b0 36
-       dc 07 05 02	// add-int/2addr       v6, v3
-       48 07 02 07	// rem-int/lit8        v7, v5, 0x2
-       d8 08 06 e5	// aget-byte           v7, v2, v7
-       d8 08 08 26	// add-int/lit8        v8, v6, -27
-       91 03 08 03	// sub-int             v3, v8, v3
-       b7 74    		// xor-int/2addr       v4, v7
-     }
-     $dexclass = {
-       6e 20 ?? ?? 10 00	// invoke-virtual      {v0, v1}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
-       ?? ?? 1f 0b    	     	// check-cast          p1, Ldalvik/system/DexClassLoader; 
-      }
+  strings:
+    /* typical XOR algo with junk operations */
+    $algo = {
+      b0 9b		        // add-int/2addr       v11, v9
+      da 0? 0? 00 	  // mul-int/lit8        v12, v11, 0
+      b3 9c 		      // div-int/2addr       v12, v9
+      b0 1c 		      // add-int/2addr       v12, v1
+      b0 5c		        // add-int/2addr       v12, v5
+      93 0? 0? 0?	    // div-int             v5, v6, v6
+      d8 0? 0? ff 	  // add-int/lit8        v5, v5, -1
+      b0 5c 		      // add-int/2addr       v12, v5
+      b4 66 		      // rem-int/2addr       v6, v6
+      b0 6c 		      // add-int/2addr       v12, v6
+      97 05 0c 0a 	  // xor-int             v5, v12, v10
+    }
+    $algo2 = {
+      b0 ??					            // add-int/2addr       v4, v12
+      da 0? 0? 00 				      // mul-int/lit8        v4, v4, 0
+      b0 ?? 	 				          // add-int/2addr       v4, v9
+      93 0? 0? 0?				        // div-int             v9, v12, v12
+      (b3 69 | db 04 04 01) 	 	// div-int/2addr       v9, v6
+       	      	      	 		   	// or:  div-int/lit8        v4, v4, 0x1
+      (b7 69 | df 04 04 01) 		// xor-int/2addr       v9, v6
+       	      	      	 		   	// or: xor-int/lit8        v4, v4, 0x1
+      b0 ??					            // add-int/2addr       v4, v9
+      94 0? 0? 0?				        // rem-int             v9, v12, v12
+      b0 ?? 	 				          // add-int/2addr       v4, v9
+      (b7 b4 | 97 04 07 09 ) 		// xor-int/2addr       v4, v11
+       	      	      	      	// or: xor-int             v4, v7, v9
+    }
+    $algo3 = {
+      b0 36
+      dc 07 05 02	  // add-int/2addr       v6, v3
+      48 07 02 07	  // rem-int/lit8        v7, v5, 0x2
+      d8 08 06 e5	  // aget-byte           v7, v2, v7
+      d8 08 08 26	  // add-int/lit8        v8, v6, -27
+      91 03 08 03	  // sub-int             v3, v8, v3
+      b7 74    		  // xor-int/2addr       v4, v7
+    }
+    $dexclass = {
+      6e 20 ?? ?? 10 00	// invoke-virtual      {v0, v1}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
+      ?? ?? 1f 0b    	  // check-cast          p1, Ldalvik/system/DexClassLoader; 
+    }
 
    condition:
      is_dex

--- a/apkid/rules/dex/packers.yara
+++ b/apkid/rules/dex/packers.yara
@@ -387,12 +387,12 @@ rule crazy_dog_wrapper : packer
     and 2 of them
 }
 
-rule jsonpacker_dex : packer
+rule jsonpacker : packer
 {
    meta:
      description = "JsonPacker"
-     sample       = "e23f0a124fdaba30c07a3c40011dd99240af081cec4cdfcb990c811126867e59"
-     author        = "Axelle Apvrille and Eduardo Novella"
+     sample      = "e23f0a124fdaba30c07a3c40011dd99240af081cec4cdfcb990c811126867e59"
+     author      = "Axelle Apvrille"
 
    strings:
      /* typical XOR algo with junk operations */
@@ -415,21 +415,40 @@ rule jsonpacker_dex : packer
 	b0 94 	 	// add-int/2addr       v4, v9
 	93 09 0c 0c	// div-int             v9, v12, v12
 	b3 69 	 	// div-int/2addr       v9, v6
-	b7 69		//  xor-int/2addr       v9, v6
+	b7 69		// xor-int/2addr       v9, v6
 	b0 94		// add-int/2addr       v4, v9
 	94 09 0c 0c	// rem-int             v9, v12, v12
 	b0 94 	 	// add-int/2addr       v4, v9
 	b7 b4		// xor-int/2addr       v4, v11
      }
-     
+     $algo3 = {
+        b0 a7		// add-int/2addr       v7, v10
+        da 07 07 00	// mul-int/lit8        v7, v7, 0
+        b0 47		// add-int/2addr       v7, v4
+        93 04 0a 0a	// div-int             v4, v10, v10
+        db 04 04 01	// div-int/lit8        v4, v4, 0x1
+        df 04 04 01	// xor-int/lit8        v4, v4, 0x1
+        b0 47		// add-int/2addr       v7, v4
+        94 04 0a 0a	// rem-int             v4, v10, v10
+        b0 47		// add-int/2addr       v7, v4
+        97 04 07 09	// xor-int             v4, v7, v9
+     }
+     $algo4 = {
+     b0 36
+     dc 07 05 02	// add-int/2addr       v6, v3
+     48 07 02 07	//  rem-int/lit8        v7, v5, 0x2
+     d8 08 06 e5	// aget-byte           v7, v2, v7
+     d8 08 08 26	// add-int/lit8        v8, v6, -27
+     91 03 08 03	// sub-int             v3, v8, v3
+     b7 74    		// xor-int/2addr       v4, v7
+     }
      $dexclass = {
        6e 20 ?? ?? 10 00	// invoke-virtual      {v0, v1}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
        ?? ?? 1f 0b    	     	// check-cast          p1, Ldalvik/system/DexClassLoader; 
-       }
+      }
 
    condition:
      is_dex
-     //and $json
-     and ($algo or $algo2)
+     and ($algo or $algo2 or $algo3 or $algo4)
      and $dexclass
 }

--- a/apkid/rules/dex/packers.yara
+++ b/apkid/rules/dex/packers.yara
@@ -397,45 +397,45 @@ rule jsonpacker : packer
   strings:
     /* typical XOR algo with junk operations */
     $algo = {
-      b0 9b		        // add-int/2addr       v11, v9
-      da 0? 0? 00 	  // mul-int/lit8        v12, v11, 0
-      b3 9c 		      // div-int/2addr       v12, v9
-      b0 1c 		      // add-int/2addr       v12, v1
-      b0 5c		        // add-int/2addr       v12, v5
-      93 0? 0? 0?	    // div-int             v5, v6, v6
-      d8 0? 0? ff 	  // add-int/lit8        v5, v5, -1
-      b0 5c 		      // add-int/2addr       v12, v5
-      b4 66 		      // rem-int/2addr       v6, v6
-      b0 6c 		      // add-int/2addr       v12, v6
-      97 05 0c 0a 	  // xor-int             v5, v12, v10
+      b0 9b               // add-int/2addr       v11, v9
+      da 0? 0? 00         // mul-int/lit8        v12, v11, 0
+      b3 9c               // div-int/2addr       v12, v9
+      b0 1c               // add-int/2addr       v12, v1
+      b0 5c               // add-int/2addr       v12, v5
+      93 0? 0? 0?         // div-int             v5, v6, v6
+      d8 0? 0? ff         // add-int/lit8        v5, v5, -1
+      b0 5c               // add-int/2addr       v12, v5
+      b4 66               // rem-int/2addr       v6, v6
+      b0 6c               // add-int/2addr       v12, v6
+      97 05 0c 0a         // xor-int             v5, v12, v10
     }
     $algo2 = {
-      b0 ??					            // add-int/2addr       v4, v12
-      da 0? 0? 00 				      // mul-int/lit8        v4, v4, 0
-      b0 ?? 	 				          // add-int/2addr       v4, v9
-      93 0? 0? 0?				        // div-int             v9, v12, v12
-      (b3 69 | db 04 04 01) 	 	// div-int/2addr       v9, v6
-       	      	      	 		   	// or:  div-int/lit8        v4, v4, 0x1
-      (b7 69 | df 04 04 01) 		// xor-int/2addr       v9, v6
-       	      	      	 		   	// or: xor-int/lit8        v4, v4, 0x1
-      b0 ??					            // add-int/2addr       v4, v9
-      94 0? 0? 0?				        // rem-int             v9, v12, v12
-      b0 ?? 	 				          // add-int/2addr       v4, v9
-      (b7 b4 | 97 04 07 09 ) 		// xor-int/2addr       v4, v11
-       	      	      	      	// or: xor-int             v4, v7, v9
+      b0 ??                     // add-int/2addr       v4, v12
+      da 0? 0? 00               // mul-int/lit8        v4, v4, 0
+      b0 ??                     // add-int/2addr       v4, v9
+      93 0? 0? 0?               // div-int             v9, v12, v12
+      (b3 69 | db 04 04 01)     // div-int/2addr       v9, v6
+                                // or:  div-int/lit8        v4, v4, 0x1
+      (b7 69 | df 04 04 01)     // xor-int/2addr       v9, v6
+                                // or: xor-int/lit8        v4, v4, 0x1
+      b0 ??                     // add-int/2addr       v4, v9
+      94 0? 0? 0?               // rem-int             v9, v12, v12
+      b0 ??                     // add-int/2addr       v4, v9
+      (b7 b4 | 97 04 07 09 )    // xor-int/2addr       v4, v11
+                                // or: xor-int             v4, v7, v9
     }
     $algo3 = {
       b0 36
-      dc 07 05 02	  // add-int/2addr       v6, v3
-      48 07 02 07	  // rem-int/lit8        v7, v5, 0x2
-      d8 08 06 e5	  // aget-byte           v7, v2, v7
-      d8 08 08 26	  // add-int/lit8        v8, v6, -27
-      91 03 08 03	  // sub-int             v3, v8, v3
-      b7 74    		  // xor-int/2addr       v4, v7
+      dc 07 05 02         // add-int/2addr       v6, v3
+      48 07 02 07         // rem-int/lit8        v7, v5, 0x2
+      d8 08 06 e5         // aget-byte           v7, v2, v7
+      d8 08 08 26         // add-int/lit8        v8, v6, -27
+      91 03 08 03         // sub-int             v3, v8, v3
+      b7 74               // xor-int/2addr       v4, v7
     }
     $dexclass = {
-      6e 20 ?? ?? 10 00	// invoke-virtual      {v0, v1}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
-      ?? ?? 1f 0b    	  // check-cast          p1, Ldalvik/system/DexClassLoader; 
+      6e 20 ?? ?? 10 00   // invoke-virtual      {v0, v1}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
+      ?? ?? 1f 0b         // check-cast          p1, Ldalvik/system/DexClassLoader; 
     }
 
    condition:

--- a/apkid/rules/dex/packers.yara
+++ b/apkid/rules/dex/packers.yara
@@ -435,7 +435,8 @@ rule jsonpacker : packer
     }
     $dexclass = {
       6e 20 ?? ?? 10 00   // invoke-virtual      {v0, v1}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
-      ?? ?? 1f 0b         // check-cast          p1, Ldalvik/system/DexClassLoader; 
+      0c ??               // move-result-object  p1
+      1f 0?               // check-cast          p1, Ldalvik/system/DexClassLoader; 
     }
 
    condition:

--- a/apkid/rules/dex/packers.yara
+++ b/apkid/rules/dex/packers.yara
@@ -398,49 +398,40 @@ rule jsonpacker : packer
      /* typical XOR algo with junk operations */
      $algo = {
        b0 9b		// add-int/2addr       v11, v9
-       da 0c 0b 00 	// mul-int/lit8        v12, v11, 0
+       da 0? 0? 00 	// mul-int/lit8        v12, v11, 0
        b3 9c 		// div-int/2addr       v12, v9
        b0 1c 		// add-int/2addr       v12, v1
        b0 5c		// add-int/2addr       v12, v5
-       93 05 06 06	// div-int             v5, v6, v6
-       d8 05 05 ff 	// add-int/lit8        v5, v5, -1
+       93 0? 0? 0?	// div-int             v5, v6, v6
+       d8 0? 0? ff 	// add-int/lit8        v5, v5, -1
        b0 5c 		// add-int/2addr       v12, v5
        b4 66 		// rem-int/2addr       v6, v6
        b0 6c 		// add-int/2addr       v12, v6
        97 05 0c 0a 	// xor-int             v5, v12, v10
      }
      $algo2 = {
-        b0 c4		// add-int/2addr       v4, v12
-	da 04 04 00 	// mul-int/lit8        v4, v4, 0
-	b0 94 	 	// add-int/2addr       v4, v9
-	93 09 0c 0c	// div-int             v9, v12, v12
-	b3 69 	 	// div-int/2addr       v9, v6
-	b7 69		// xor-int/2addr       v9, v6
-	b0 94		// add-int/2addr       v4, v9
-	94 09 0c 0c	// rem-int             v9, v12, v12
-	b0 94 	 	// add-int/2addr       v4, v9
-	b7 b4		// xor-int/2addr       v4, v11
+       b0 ??					// add-int/2addr       v4, v12
+       da 0? 0? 00 				// mul-int/lit8        v4, v4, 0
+       b0 ?? 	 				// add-int/2addr       v4, v9
+       93 0? 0? 0?				// div-int             v9, v12, v12
+       (b3 69 | db 04 04 01) 	 	// div-int/2addr       v9, v6
+       	      	      	 		   		// or  div-int/lit8        v4, v4, 0x1
+       (b7 69 | df 04 04 01) 		// xor-int/2addr       v9, v6
+       	      	      	 		   		// or xor-int/lit8        v4, v4, 0x1
+       b0 ??					// add-int/2addr       v4, v9
+       94 0? 0? 0?				// rem-int             v9, v12, v12
+       b0 ?? 	 				// add-int/2addr       v4, v9
+       (b7 b4 | 97 04 07 09 ) 		// xor-int/2addr       v4, v11
+       	      	      	      		   		// or xor-int             v4, v7, v9
      }
      $algo3 = {
-        b0 a7		// add-int/2addr       v7, v10
-        da 07 07 00	// mul-int/lit8        v7, v7, 0
-        b0 47		// add-int/2addr       v7, v4
-        93 04 0a 0a	// div-int             v4, v10, v10
-        db 04 04 01	// div-int/lit8        v4, v4, 0x1
-        df 04 04 01	// xor-int/lit8        v4, v4, 0x1
-        b0 47		// add-int/2addr       v7, v4
-        94 04 0a 0a	// rem-int             v4, v10, v10
-        b0 47		// add-int/2addr       v7, v4
-        97 04 07 09	// xor-int             v4, v7, v9
-     }
-     $algo4 = {
-     b0 36
-     dc 07 05 02	// add-int/2addr       v6, v3
-     48 07 02 07	//  rem-int/lit8        v7, v5, 0x2
-     d8 08 06 e5	// aget-byte           v7, v2, v7
-     d8 08 08 26	// add-int/lit8        v8, v6, -27
-     91 03 08 03	// sub-int             v3, v8, v3
-     b7 74    		// xor-int/2addr       v4, v7
+       b0 36
+       dc 07 05 02	// add-int/2addr       v6, v3
+       48 07 02 07	// rem-int/lit8        v7, v5, 0x2
+       d8 08 06 e5	// aget-byte           v7, v2, v7
+       d8 08 08 26	// add-int/lit8        v8, v6, -27
+       91 03 08 03	// sub-int             v3, v8, v3
+       b7 74    		// xor-int/2addr       v4, v7
      }
      $dexclass = {
        6e 20 ?? ?? 10 00	// invoke-virtual      {v0, v1}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
@@ -449,6 +440,6 @@ rule jsonpacker : packer
 
    condition:
      is_dex
-     and ($algo or $algo2 or $algo3 or $algo4)
+     and ($algo or $algo2 or $algo3)
      and $dexclass
 }

--- a/apkid/rules/dex/packers.yara
+++ b/apkid/rules/dex/packers.yara
@@ -386,3 +386,50 @@ rule crazy_dog_wrapper : packer
     is_dex
     and 2 of them
 }
+
+rule jsonpacker_dex : packer
+{
+   meta:
+     description = "JsonPacker"
+     sample       = "e23f0a124fdaba30c07a3c40011dd99240af081cec4cdfcb990c811126867e59"
+     author        = "Axelle Apvrille and Eduardo Novella"
+
+   strings:
+     /* typical XOR algo with junk operations */
+     $algo = {
+       b0 9b		// add-int/2addr       v11, v9
+       da 0c 0b 00 	// mul-int/lit8        v12, v11, 0
+       b3 9c 		// div-int/2addr       v12, v9
+       b0 1c 		// add-int/2addr       v12, v1
+       b0 5c		// add-int/2addr       v12, v5
+       93 05 06 06	// div-int             v5, v6, v6
+       d8 05 05 ff 	// add-int/lit8        v5, v5, -1
+       b0 5c 		// add-int/2addr       v12, v5
+       b4 66 		// rem-int/2addr       v6, v6
+       b0 6c 		// add-int/2addr       v12, v6
+       97 05 0c 0a 	// xor-int             v5, v12, v10
+     }
+     $algo2 = {
+        b0 c4		// add-int/2addr       v4, v12
+	da 04 04 00 	// mul-int/lit8        v4, v4, 0
+	b0 94 	 	// add-int/2addr       v4, v9
+	93 09 0c 0c	// div-int             v9, v12, v12
+	b3 69 	 	// div-int/2addr       v9, v6
+	b7 69		//  xor-int/2addr       v9, v6
+	b0 94		// add-int/2addr       v4, v9
+	94 09 0c 0c	// rem-int             v9, v12, v12
+	b0 94 	 	// add-int/2addr       v4, v9
+	b7 b4		// xor-int/2addr       v4, v11
+     }
+     
+     $dexclass = {
+       6e 20 ?? ?? 10 00	// invoke-virtual      {v0, v1}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
+       ?? ?? 1f 0b    	     	// check-cast          p1, Ldalvik/system/DexClassLoader; 
+       }
+
+   condition:
+     is_dex
+     //and $json
+     and ($algo or $algo2)
+     and $dexclass
+}


### PR DESCRIPTION
This packer is found in :
- `49d167f8f7427f0340297ae1c89ce4a216a8e64c55294f8e422f1f972732bae7`
- `5b9049c392eaf83b12b98419f14ece1b00042592b003a17e4e6f0fb466281368` (see [this blog post for info on this packer](https://cryptax.medium.com/multidex-trick-to-unpack-android-bianlian-ed52eb791e56)).

Beware, both samples are malicious.
I don't know what is the official name of this packer.

The packing mechanism consists in re-implementing Multidex support, while obfuscating important strings (e.g `multidex.version`) and decrypting the payload. The code fetches the payload from the assets and decrypts it. From the decrypted version, it creates a Zip file containing the DEX and loads that.

The detection rule matches (1) the de-obfuscation of some of the typical Multidex strings, and (2) the decryption of the asset.

It detects the 2 APKs with name "MultidexPacker":

```
apkid ~/samples/multidex/*.apk
[+] APKiD 2.1.3 :: from RedNaga :: rednaga.io
[*] /home/axelle/samples/multidex/08362_Video_Oynat.apk!classes.dex
 |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, SIM operator check, device ID check, emulator file check, network operator name check, possible Build.SERIAL check, possible VM check, ro.kernel.qemu check, ro.product.device check, subscriber ID check
 |-> compiler : dexlib 2.x
 |-> packer : MultidexPacker
[*] /home/axelle/samples/multidex/49d167f8f7427f0340297ae1c89ce4a216a8e64c55294f8e422f1f972732bae7.apk!classes.dex
 |-> anti_disassembly : illegal class name
 |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, SIM operator check, device ID check, emulator file check, network operator name check, possible Build.SERIAL check, possible VM check, possible ro.secure check, ro.kernel.qemu check, ro.product.device check, subscriber ID check
 |-> compiler : dexlib 2.x
 |-> packer : MultidexPacker
```

I have also tested the rule against a bunch of other APKs that do not have this packer, and did not get any False Positive. This is not bullet proof, but it looks like it is working :)

Feel free to *rename* the packer is you know what is its official name.

