### PR TITLE
Update protectors.yara to add Codestage Anti-Cheat 

### DIFF
--- a/apkid/rules/apk/protectors.yara
+++ b/apkid/rules/apk/protectors.yara
@@ -88,3 +88,25 @@ rule vkey_apk : protector
     1 of ($asseta*) and
     1 of ($assetb*)
 }
+
+rule kiwisec : protector
+{
+  meta:
+    description = "KiwiSec ApkProtector"
+    url         = "https://github.com/iKiwiSec/KiwiApkProtect"
+    author      = "Govind Sharma"
+    sample      = "d108652bd1b685765e3ada2b7376e3c3ff67f8162afcf8bad91e0aef79b7b08a"
+
+  strings:
+     $kw1  = "libkwscmm.so"
+     $kw2  = "libkwscr.so"
+     $kw3  = "libkwslinker.so"
+     $kw4  = "libKwProtectSDK.so"
+     $kw5  = "libKwAppGuardSDK.so"
+     $kw6  = "kwmkadp_arm64-v8a"
+     $kw7  = "kwmkadp_armeabi-v7a"
+     $kw8  = "kiwiguard.lic"
+
+  condition:
+    is_apk and any of ($kw*)
+}

--- a/apkid/rules/elf/protectors.yara
+++ b/apkid/rules/elf/protectors.yara
@@ -179,11 +179,11 @@ rule codestage_anticheat : protector
     $detection3  = "Time Cheating Detector"
     $detection4  = "WallHack Detector"
     $detection5  = "Injection Detector"
-    $check1      = "walk through the walls"
-    $check2      = "see through the walls"
-    $check3      = "shoot through the walls"
-    $check4      = "http://codestage.net"
+    $detection6  = "walk through the walls"
+    $detection7  = "see through the walls"
+    $detection8  = "shoot through the walls"
+    $detection9  = "http://codestage.net"
 
   condition:
-    is_elf and $code and $code2 and 1 of ($detection*) and 1 of ($check*)
+    is_elf and $code and $code2 and 2 of ($detection*)
 }

--- a/apkid/rules/elf/protectors.yara
+++ b/apkid/rules/elf/protectors.yara
@@ -172,8 +172,8 @@ rule codestage_anticheat_elf : protector
     sample      = "404c618c03040c44950c1678e9fb5399576f146ccfdbf43c0208869831519d35"
 
   strings:
-    $code  = "Code Stage"
-    $code2  = "Anti-Cheat Toolkit"
+    $code        = "Code Stage"
+    $code2       = "Anti-Cheat Toolkit"
     $detection1  = "Obscured Cheating Detector"
     $detection2  = "Speed Hack Detector"
     $detection3  = "Time Cheating Detector"

--- a/apkid/rules/elf/protectors.yara
+++ b/apkid/rules/elf/protectors.yara
@@ -163,7 +163,7 @@ rule vkey_elf : protector
     is_elf and $libname and 1 of ($vos*) and 1 of ($detection*) and 1 of ($jni*)
 }
 
-rule codestage_anticheat_elf : protector
+rule codestage_anticheat : protector
 {
   meta:
     description = "CodeStage Anti-Cheat"

--- a/apkid/rules/elf/protectors.yara
+++ b/apkid/rules/elf/protectors.yara
@@ -162,3 +162,28 @@ rule vkey_elf : protector
   condition:
     is_elf and $libname and 1 of ($vos*) and 1 of ($detection*) and 1 of ($jni*)
 }
+
+rule codestage_anticheat_elf : protector
+{
+  meta:
+    description = "CodeStage Anti-Cheat"
+    url         = "http://codestage.net"
+    author      = "Govind Sharma"
+    sample      = "404c618c03040c44950c1678e9fb5399576f146ccfdbf43c0208869831519d35"
+
+  strings:
+    $code  = "Code Stage"
+    $code2  = "Anti-Cheat Toolkit"
+    $detection1  = "Obscured Cheating Detector"
+    $detection2  = "Speed Hack Detector"
+    $detection3  = "Time Cheating Detector"
+    $detection4  = "WallHack Detector"
+    $detection5  = "Injection Detector"
+    $check1      = "walk through the walls"
+    $check2      = "see through the walls"
+    $check3      = "shoot through the walls"
+    $check4      = "http://codestage.net"
+
+  condition:
+    is_elf and $code and $code2 and 1 of ($detection*) and 1 of ($check*)
+}


### PR DESCRIPTION
For issue 
https://github.com/rednaga/APKiD/issues/297

Some point to noticed -

```sh
$code  = "Code Stage"
$code2  = "Anti-Cheat Toolkit"
```
is always present . 

Choosed any 1 of them only . why ? 
Because all games are different and not all of them required all anti cheat so developer add  according to game but as Anticheat is used , any 1 of them must be exist
```sh
    $detection1  = "Obscured Cheating Detector"
    $detection2  = "Speed Hack Detector"
    $detection3  = "Time Cheating Detector"
    $detection4  = "WallHack Detector"
    $detection5  = "Injection Detector"
```
70% of samples have its codestage.net website present as string and rest not have so it is not must but it can be used as detection if occurred with 1st two rules along with $check* strings
