### PR TITLE
Fix #314 - OLLVM v8 not detected

### DIFF
--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -155,6 +155,29 @@ rule ollvm_v6_0 : obfuscator
     not ollvm_v6_0_strenc
 }
 
+
+rule ollvm_v8 : obfuscator
+{
+  meta:
+    description = "Obfuscator-LLVM version 8.x"
+    url         = "https://github.com/obfuscator-llvm/obfuscator/wiki"
+    url2        = "https://github.com/heroims/obfuscator"
+    sample      = "2c720f5ec740f4c8571dbba205eadba483556c5c387fe88ff25192b25552da0f"
+    author      = "Eduardo Novella"
+
+  strings:
+    /*
+      [0x0000a5bc]> izzq~+obfuscator,ollvm,clang
+      0x1 263 262 Android (4751641 based on r328903) clang version 7.0.2 (https://android.googlesource.com/toolchain/clang 003100370607242ddd5815e4a043907ea9004281) (https://android.googlesource.com/toolchain/llvm 1d739ffb0366421d383e04ff80ec2ee591315116) (based on LLVM 7.0.2svn)
+      0x108 155 154 Obfuscator-LLVM clang version 8.0.0  (https://github.com/heroims/obfuscator.git 29d9dc8c1bd662f3a73d1b1b009266af1786b7b8) (based on Obfuscator-LLVM 8.0.0)
+    */
+    $ollvm = "Obfuscator-LLVM clang version 8."
+
+  condition:
+    is_elf and all of them
+}
+
+
 rule ollvm_v9 : obfuscator
 {
   meta:
@@ -292,6 +315,7 @@ rule ollvm : obfuscator
     not ollvm_v6_0 and
     not ollvm_v6_0_strenc and
     not ollvm_strenc and
+    not ollvm_v8 and
     not ollvm_v9 and
     not ollvm_v9_strenc
 }


### PR DESCRIPTION

```sh
docker/apkid.sh /tmp/optool.so 
[+] APKiD 2.1.3 :: from RedNaga :: rednaga.io
[*] /input/optool.so
 |-> obfuscator : Obfuscator-LLVM version 8.x
```

@apkunpacker Can you approve it?