### PR TITLE
Add LSPosed LLVM-based obfuscator seen in Momo, Shamiko and many others

### DIFF
--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -414,6 +414,25 @@ rule byteguard_unknown : obfuscator
     not byteguard_0_9_3
 }
 
+rule ollvm_lsposed : obfuscator
+{
+  meta:
+    description = "LSPosed Obfuscator-LLVM (string encryption)"
+    url         = "https://github.com/LSPosed/LSPosed.github.io/releases"
+    sample      = "90ffa13afcf084aa3717a59cf5812517223c6cc4a6265cb191c929ef3a198c95/" // Momo, shamiko, and root hiders
+    author      = "Eduardo Novella"
+
+  strings:
+    // Android (dev, based on r416183c1) clang version 12.0.8 (...)
+    // decrypt.e94930e06527fedf
+    $exports = /decrypt\.[0-9a-f]{14,16}/
+
+  condition:
+    is_elf and
+    #exports > 5
+    // for any i in (0..elf.symtab_entries): (elf.symtab[i].name matches /decrypt\.[0-9a-f]{14,16}/)
+}
+
 rule firehash : obfuscator
 {
   meta:


### PR DESCRIPTION
Hi @CalebFenton,

I have come across various apps with this protection and wanted to detect it.  In the rule below, the iterator against the symbol table wasn't matching 100% in my samples. The ELF yara module seems a bit limited to accomplish a perfect rule, would it be okay if we merge this rule as it is now?

```c
rule ollvm_lsposed : obfuscator
{
  meta:
    description = "LSPosed Obfuscator-LLVM (string encryption)"
    url         = "https://github.com/LSPosed/LSPosed.github.io/releases"
    sample      = "90ffa13afcf084aa3717a59cf5812517223c6cc4a6265cb191c929ef3a198c95/" // Momo, shamiko, and root hiders
    author      = "Eduardo Novella"

  strings:
    // Android (dev, based on r416183c1) clang version 12.0.8 (...)
    // decrypt.e94930e06527fedf
    $exports = /decrypt\.[0-9a-f]{14,16}/

  condition:
    is_elf and
    #exports > 5
    // for any i in (0..elf.symtab_entries): (elf.symtab[i].name matches /decrypt\.[0-9a-f]{14,16}/)
}
```

```sh
$ apkid momo-v4.4.1.apk
[+] APKiD 2.1.4 :: from RedNaga :: rednaga.io
[*] momo-v4.4.1.apk!classes.dex
 |-> anti_vm : Build.FINGERPRINT check, Build.MANUFACTURER check
 |-> compiler : r8 without marker (suspicious)
[*] momo-v4.4.1.apk!lib/arm64-v8a/libmahoshojo.so
 |-> anti_hook : syscalls
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] momo-v4.4.1.apk!lib/armeabi-v7a/libmahoshojo.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] momo-v4.4.1.apk!lib/x86/libmahoshojo.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] momo-v4.4.1.apk!lib/x86_64/libmahoshojo.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
```

```sh
shamiko$ apkid .
[+] APKiD 2.1.4 :: from RedNaga :: rednaga.io
[*] ./Shamiko-v0.4.1-95-release.zip!zygisk/arm64-v8a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.1-95-release.zip!zygisk/armeabi-v7a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.1-95-release.zip!zygisk/x86.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.1-95-release.zip!zygisk/x86_64.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.2-97-release.zip!zygisk/arm64-v8a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.2-97-release.zip!zygisk/armeabi-v7a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.2-97-release.zip!zygisk/x86.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.2-97-release.zip!zygisk/x86_64.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.3-100-release.zip!zygisk/arm64-v8a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.3-100-release.zip!zygisk/armeabi-v7a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.3-100-release.zip!zygisk/x86.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.3-100-release.zip!zygisk/x86_64.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.4-106-release.zip!zygisk/arm64-v8a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.4-106-release.zip!zygisk/armeabi-v7a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.4-106-release.zip!zygisk/x86.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.4.4-106-release.zip!zygisk/x86_64.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.0-110-release.zip!zygisk/arm64-v8a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.0-110-release.zip!zygisk/armeabi-v7a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.0-110-release.zip!zygisk/x86.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.0-110-release.zip!zygisk/x86_64.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.1-115-release.zip!zygisk/arm64-v8a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.1-115-release.zip!zygisk/armeabi-v7a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.1-115-release.zip!zygisk/x86.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.1-115-release.zip!zygisk/x86_64.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.2-120-release.zip!zygisk/arm64-v8a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.2-120-release.zip!zygisk/armeabi-v7a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.2-120-release.zip!zygisk/x86.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.5.2-120-release.zip!zygisk/x86_64.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.6-126-release.zip!zygisk/arm64-v8a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.6-126-release.zip!zygisk/armeabi-v7a.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.6-126-release.zip!zygisk/x86.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
[*] ./Shamiko-v0.6-126-release.zip!zygisk/x86_64.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
```

```sh
$ apkid MagiskDetector1.0.1.apk
[+] APKiD 2.1.4 :: from RedNaga :: rednaga.io
[*] MagiskDetector1.0.1.apk!classes.dex
 |-> compiler : dexlib 2.x
[*] MagiskDetector1.0.1.apk!lib/arm64-v8a/libnullptr.so
 |-> obfuscator : LSPosed Obfuscator-LLVM (string encryption)
```
