### PR TITLE
Add Korean protector: VGuard #339

### DIFF
--- a/apkid/rules/apk/protectors.yara
+++ b/apkid/rules/apk/protectors.yara
@@ -146,7 +146,7 @@ rule vguard : protector
     author      = "dustty0"
 
   strings:
-    $lib    = /lib\/(x86\_64|armeabi\-v7a|arm64\-v8a|x86)\/libedex\.so/
+    $lib    = /lib\/(arm.*|x86.*)\/libedex\.so/
     $asset1 = /assets\/dexsky\.(d|e)b(a|b|x|y)/
     $asset2 = /assets\/dexsky\.ini/
     $asset3 = /assets\/dex[a-z0-9]{3}\.zip/

--- a/apkid/rules/apk/protectors.yara
+++ b/apkid/rules/apk/protectors.yara
@@ -136,3 +136,22 @@ rule ahope_appshield : protector
     condition:
       is_apk and any of them
 }
+
+rule vguard : protector
+{
+  meta:
+    description = "VGuard"
+    url         = "https://www.vguard.co.kr"
+    sample      = "7024bdadb53cbec86a39de845108b182ed2f7b3f0e7c0b876a948e1532ec5b9f"
+    author      = "dustty0"
+
+  strings:
+    $lib    = /lib\/(x86\_64|armeabi\-v7a|arm64\-v8a|x86)\/libedex\.so/
+    $asset1 = /assets\/dexsky\.(d|e)b(a|b|x|y)/
+    $asset2 = /assets\/dexsky\.ini/
+    $asset3 = /assets\/dex[a-z0-9]{3}\.zip/
+    $asset4 = /assets\/vguard\.(key|enginehash)/
+
+  condition:
+    is_apk and any of them
+}

--- a/apkid/rules/dex/protectors.yara
+++ b/apkid/rules/dex/protectors.yara
@@ -255,5 +255,19 @@ rule ahope_appshield : protector
       is_dex and any of them
 }
 
+rule vguard : protector
+{
+  meta:
+    description = "VGuard"
+    url         = "https://www.vguard.co.kr"
+    sample      = "7024bdadb53cbec86a39de845108b182ed2f7b3f0e7c0b876a948e1532ec5b9f"
+    author      = "dustty0"
 
+  strings:
+    $pkg = {
+           4c6b 722f 636f 2f73 646b 2f76 6775 6172 6432 // Lkr/co/sdk/vguard2
+    }
 
+  condition:
+    is_dex and any of them
+}


### PR DESCRIPTION
This PR will add the yara rule for Korean protector named VGuard from #339.

- URL: https://www.vguard.co.kr
- Samples: 
  - [https://apkcombo.com/mypds-나의금융생활/kr.or.mydatacenter.pds/](https://apkcombo.com/mypds-%EB%82%98%EC%9D%98%EA%B8%88%EC%9C%B5%EC%83%9D%ED%99%9C/kr.or.mydatacenter.pds/)
  - [https://apkcombo.com/뱅크페이-금융기관-공동-계좌이체-결제-제로페이/com.kftc.bankpay.android/](https://apkcombo.com/%EB%B1%85%ED%81%AC%ED%8E%98%EC%9D%B4-%EA%B8%88%EC%9C%B5%EA%B8%B0%EA%B4%80-%EA%B3%B5%EB%8F%99-%EA%B3%84%EC%A2%8C%EC%9D%B4%EC%B2%B4-%EA%B2%B0%EC%A0%9C-%EC%A0%9C%EB%A1%9C%ED%8E%98%EC%9D%B4/com.kftc.bankpay.android/)
  - [https://apkcombo.com/어카운트인포-계좌정보통합관리/com.kftc.payinfo.android/](https://apkcombo.com/%EC%96%B4%EC%B9%B4%EC%9A%B4%ED%8A%B8%EC%9D%B8%ED%8F%AC-%EA%B3%84%EC%A2%8C%EC%A0%95%EB%B3%B4%ED%86%B5%ED%95%A9%EA%B4%80%EB%A6%AC/com.kftc.payinfo.android/)