### PR TITLE
Fix appdome Aarch64 with no exported symbols, match segments now

### DIFF
--- a/apkid/rules/elf/protectors.yara
+++ b/apkid/rules/elf/protectors.yara
@@ -98,6 +98,21 @@ rule appdome_elf : protector
     )
 }
 
+rule appdome_elf_a : protector
+{
+  meta:
+    description = "Appdome"
+    sample      = "0143ddce30b16890180cfa71c49520bde4cce706762f4da756e8c4d06283a481"
+    url         = "https://www.appdome.com/"
+    author      = "Eduardo Novella"
+
+  condition:
+    is_elf and not appdome_elf and
+      // Match at least 2 section names from hook,.hookname,adinit,.adi,ipcent,ipcsel
+      for 2 i in (0..elf.number_of_sections):
+        (elf.sections[i].name matches /(hook|\.hookname|adinit|\.adi|ipcent|ipcsel)/)
+}
+
 rule metafortress : protector
 {
   meta:


### PR DESCRIPTION
# Sample
https://www.virustotal.com/gui/file/0143ddce30b16890180cfa71c49520bde4cce706762f4da756e8c4d06283a481?nocache=1

# Issue
Arm64 binaries are not exporting symbols as before

# Fix
Target segments names with similar names

# Before
```sh
[*] com.bpi.ng.app.apk!lib/armeabi-v7a/libloader.so
 |-> protector : Appdome
```

# After
```sh
 [*] com.bpi.ng.app.apk!lib/arm64-v8a/libloader.so
 |-> protector : Appdome
[*] com.bpi.ng.app.apk!lib/armeabi-v7a/libloader.so
 |-> protector : Appdome
```