### PR TITLE
Add AY literal obfuscation

### DIFF
--- a/apkid/rules/elf/obfuscators.yara
+++ b/apkid/rules/elf/obfuscators.yara
@@ -850,3 +850,19 @@ rule androidrepublic_vip : obfuscator
   condition:
     is_elf and all of them
 }
+
+rule ay : obfuscator
+{
+  meta:
+    description = "AY"
+    url         = "https://github.com/adamyaxley/Obfuscate"
+    sample      = "35b451d7cb3ad93ece0cc1c9119356b7f11876ef116051fa1343bf88f0e2ef75"
+    author      = "Eduardo Novella"
+
+  strings:
+    $export = /\_ZN2ay\d\dobfuscated_dataILy(.*)decryptEv/
+
+  condition:
+    is_elf and all of them
+}
+


### PR DESCRIPTION
Hi there,

Does anyone know why the ELF module is failing at checking the symbol table?

The regex has been simplified to make it simple and observe changes in the output. Nothing matched in my testing. Any clue anyone?

```sh
     for any i in (0..elf.symtab_entries): (
       elf.symtab[i].name matches /(.*)obfuscated\_data(.*)/
     )
```