### PR TITLE
improve yidun(NetEase) detection rule

### DIFF
--- a/apkid/rules/apk/packers.yara
+++ b/apkid/rules/apk/packers.yara
@@ -786,9 +786,11 @@ rule yidun : packer
     $entry_point = "Lcom/netease/nis/wrapper/Entry"
     $jni_func = "Lcom/netease/nis/wrapper/MyJni"
     $lib = "libnesec.so"
+    $nedata = "assets/nedata.db"
+    $nedig = "assets/nedig.properties"
 
   condition:
-    is_apk and (#lib > 1) or ($anti_trick and $entry_point and $jni_func)
+    is_apk and (#lib > 1 or ($anti_trick and $entry_point and $jni_func) or ($nedata and $nedig))
 }
 
 rule apkpacker : packer


### PR DESCRIPTION
Sample: `com.gohitv.hitv`
Hash: `d5ddf0fbd34690040f7abe14395c791ab6f143c0b2f8d9b7e9e05e1ccd4b5be9`

Before APKiD Result:
```shell
╰─> apkid ../hitv_3.7.5.apk
[+] APKiD 2.1.5 :: from RedNaga :: rednaga.io
[*] ../hitv_3.7.5.apk!assets/audience_network.dex
 |-> anti_debug : Debug.isDebuggerConnected() check
 |-> compiler : unknown (please file detection issue!)
[*] ../hitv_3.7.5.apk!classes.dex
 |-> anti_debug : Debug.isDebuggerConnected() check
 |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, SIM operator check, device ID check, emulator file check, network operator name check, possible Build.SERIAL check, possible VM check, ro.hardware check, ro.kernel.qemu check
 |-> compiler : dexlib 2.x
 ```
 
 Now:
 ```shell
╰─> apkid ../hitv_3.7.5.apk
[+] APKiD 2.1.5 :: from RedNaga :: rednaga.io
[*] ../hitv_3.7.5.apk
 |-> packer : yidun
[*] ../hitv_3.7.5.apk!assets/audience_network.dex
 |-> anti_debug : Debug.isDebuggerConnected() check
 |-> compiler : unknown (please file detection issue!)
[*] ../hitv_3.7.5.apk!classes.dex
 |-> anti_debug : Debug.isDebuggerConnected() check
 |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, SIM operator check, device ID check, emulator file check, network operator name check, possible Build.SERIAL check, possible VM check, ro.hardware check, ro.kernel.qemu check
 |-> compiler : dexlib 2.x
 ```