### PR TITLE
Enhance r8 compiler rule

### DIFF
--- a/apkid/rules/dex/compilers.yara
+++ b/apkid/rules/dex/compilers.yara
@@ -414,68 +414,6 @@ rule dexmerge : manipulator
     dexmerge_map_type_order
 }
 
-rule d8_debug_unsigned : compiler
-{
-  meta:
-    description = "d8 debug (unsigned & possible d8 jar/class2dex)"
-
-  strings:
-    // Example: ~~D8{"backend":"dex","compilation-mode":"debug","has-checksums":false
-    $marker = { 64 65 62 75 67 22 2C 22 68 61 73 2D 63 68 65 63 6B 73 75 6D 73 22 3A 66 61 6C 73 65 }
-    $backend = { 7E 7E 44 38 7B 22 62 61 63 6B 65 6E 64 22 3A 22 64 65 78 22 } // ~~D8{"backend":"dex"
-
-  condition:
-    r8_marker
-    and all of them
-}
-
-rule d8_debug_signed : compiler
-{
-  meta:
-    description = "d8 debug (signed)"
-
-  strings:
-    // Example: ~~D8{"backend":"dex","compilation-mode":"debug","has-checksums":true
-    $marker = { 64 65 62 75 67 22 2C 22 68 61 73 2D 63 68 65 63 6B 73 75 6D 73 22 3A 74 72 75 65 }
-    $backend = { 7E 7E 44 38 7B 22 62 61 63 6B 65 6E 64 22 3A 22 64 65 78 22 } // ~~D8{"backend":"dex"
-
-  condition:
-    r8_marker
-    and all of them
-}
-
-rule d8_release_unsigned : compiler
-{
-  meta:
-    description = "d8 release (unsigned)"
-
-  strings:
-    // Example: ~~D8{"backend":"dex","compilation-mode":"release","has-checksums":false
-    $marker = { 72 65 6C 65 61 73 65 22 2C 22 68 61 73 2D 63 68 65 63 6B 73 75 6D 73 22 3A 66 61 6C 73 65 }
-    $backend = { 7E 7E 44 38 7B 22 62 61 63 6B 65 6E 64 22 3A 22 64 65 78 22 } // ~~D8{"backend":"dex"
-
-  condition:
-    r8_marker
-    and not (r8_map_type_order or ambiguous_tiny_dex_map_type_order)
-    and all of them
-}
-
-rule d8_release_signed : compiler
-{
-  meta:
-    description = "d8 release (signed)"
-
-  strings:
-    // Example: ~~D8{"backend":"dex","compilation-mode":"release","has-checksums":true
-    $marker = { 72 65 6C 65 61 73 65 22 2C 22 68 61 73 2D 63 68 65 63 6B 73 75 6D 73 22 3A 74 72 75 65 }
-    $backend = { 7E 7E 44 38 7B 22 62 61 63 6B 65 6E 64 22 3A 22 64 65 78 22 } // ~~D8{"backend":"dex"
-
-  condition:
-    r8_marker
-    and not (r8_map_type_order or ambiguous_tiny_dex_map_type_order)
-    and all of them
-}
-
 rule unknown_compiler : compiler {
   meta:
     description = "unknown (please file detection issue!)"
@@ -488,7 +426,5 @@ rule unknown_compiler : compiler {
       or (r8 or r8_merged or r8_no_marker)
       or (jack_generic or jack_3x or jack_4x or jack_4_12 or jack_5x)
       or (dexmerge)
-      or (d8_debug_unsigned or d8_debug_signed)
-      or (d8_release_unsigned or d8_release_signed)
     )
 }

--- a/apkid/rules/dex/compilers.yara
+++ b/apkid/rules/dex/compilers.yara
@@ -176,7 +176,8 @@ private rule r8_marker : internal
 
   strings:
     // Example: ~~D8{"compilation-mode":"
-    $marker = { 00 [1-2] 7E 7E ( 44 | 52 | 4C ) 38 7B 22 63 6F 6D 70 69 6C 61 74 69 6F 6E 2D 6D 6F 64 65 22 3A 22 }
+    // OR: ~~D8{"backend":"dex","compilation-mode":"
+    $marker = { 00 [1-2] 7E 7E ( 44 | 52 | 4C ) 38 7B 22 [0-16] 63 6F 6D 70 69 6C 61 74 69 6F 6E 2D 6D 6F 64 65 22 3A 22 }
 
   condition:
     /*
@@ -413,6 +414,68 @@ rule dexmerge : manipulator
     dexmerge_map_type_order
 }
 
+rule d8_debug_unsigned : compiler
+{
+  meta:
+    description = "d8 debug (unsigned & possible d8 jar/class2dex)"
+
+  strings:
+    // Example: ~~D8{"backend":"dex","compilation-mode":"debug","has-checksums":false
+    $marker = { 64 65 62 75 67 22 2C 22 68 61 73 2D 63 68 65 63 6B 73 75 6D 73 22 3A 66 61 6C 73 65 }
+    $backend = { 7E 7E 44 38 7B 22 62 61 63 6B 65 6E 64 22 3A 22 64 65 78 22 } // ~~D8{"backend":"dex"
+
+  condition:
+    r8_marker
+    and all of them
+}
+
+rule d8_debug_signed : compiler
+{
+  meta:
+    description = "d8 debug (signed)"
+
+  strings:
+    // Example: ~~D8{"backend":"dex","compilation-mode":"debug","has-checksums":true
+    $marker = { 64 65 62 75 67 22 2C 22 68 61 73 2D 63 68 65 63 6B 73 75 6D 73 22 3A 74 72 75 65 }
+    $backend = { 7E 7E 44 38 7B 22 62 61 63 6B 65 6E 64 22 3A 22 64 65 78 22 } // ~~D8{"backend":"dex"
+
+  condition:
+    r8_marker
+    and all of them
+}
+
+rule d8_release_unsigned : compiler
+{
+  meta:
+    description = "d8 release (unsigned)"
+
+  strings:
+    // Example: ~~D8{"backend":"dex","compilation-mode":"release","has-checksums":false
+    $marker = { 72 65 6C 65 61 73 65 22 2C 22 68 61 73 2D 63 68 65 63 6B 73 75 6D 73 22 3A 66 61 6C 73 65 }
+    $backend = { 7E 7E 44 38 7B 22 62 61 63 6B 65 6E 64 22 3A 22 64 65 78 22 } // ~~D8{"backend":"dex"
+
+  condition:
+    r8_marker
+    and not (r8_map_type_order or ambiguous_tiny_dex_map_type_order)
+    and all of them
+}
+
+rule d8_release_signed : compiler
+{
+  meta:
+    description = "d8 release (signed)"
+
+  strings:
+    // Example: ~~D8{"backend":"dex","compilation-mode":"release","has-checksums":true
+    $marker = { 72 65 6C 65 61 73 65 22 2C 22 68 61 73 2D 63 68 65 63 6B 73 75 6D 73 22 3A 74 72 75 65 }
+    $backend = { 7E 7E 44 38 7B 22 62 61 63 6B 65 6E 64 22 3A 22 64 65 78 22 } // ~~D8{"backend":"dex"
+
+  condition:
+    r8_marker
+    and not (r8_map_type_order or ambiguous_tiny_dex_map_type_order)
+    and all of them
+}
+
 rule unknown_compiler : compiler {
   meta:
     description = "unknown (please file detection issue!)"
@@ -425,5 +488,7 @@ rule unknown_compiler : compiler {
       or (r8 or r8_merged or r8_no_marker)
       or (jack_generic or jack_3x or jack_4x or jack_4_12 or jack_5x)
       or (dexmerge)
+      or (d8_debug_unsigned or d8_debug_signed)
+      or (d8_release_unsigned or d8_release_signed)
     )
 }


### PR DESCRIPTION
Minor enhancement in R8 compiler rule

Recent versions of R8 marker includes `"backend":"dex",` which causes APKiD to miss the marker detection and flag it as suspicious.