### PR TITLE
add rule for res guard

### DIFF
--- a/apkid/rules/apk/protectors.yara
+++ b/apkid/rules/apk/protectors.yara
@@ -240,14 +240,14 @@ rule shield_sdk : protector
 rule andres : manipulator
 {
     meta:
-    description = "Resources Confusion"
-    url         = "https://github.com/shwenzhang/AndResGuard"
-    sample      = "45610fcb6ba935db0bf1bd94d672a848852ee9665cebaab7b3d4d7497d8e730f"
-    author      = "Abhi"
+      description = "Resources Confusion"
+      url         = "https://github.com/shwenzhang/AndResGuard"
+      sample      = "45610fcb6ba935db0bf1bd94d672a848852ee9665cebaab7b3d4d7497d8e730f"
+      author      = "Abhi"
 
     strings:
-        $res = /res\/[^\/]+\.xml/
+      $res = /res\/[^\/]+\.xml/
 
     condition:
-        is_apk and #res > 10
+      is_apk and #res > 10
 }


### PR DESCRIPTION
- closes #384

It's no longer the case of AndResGuard only, build of every APK generated with the Gradle `assembleRelease` job produces such output, so "Resources Confusion" is used in the name instead.