### PR TITLE
tighten up naga rule

### DIFF
--- a/apkid/rules/apk/packers.yara
+++ b/apkid/rules/apk/packers.yara
@@ -696,7 +696,7 @@ rule naga : packer
 
   strings:
     // libedog | libfdog | libvdog etc. - lib name changes a/c to edition
-    $lib   = /lib.dog\.so/
+    $lib   = /lib(e|d|f|v)dog\.so/
     $lib2  = "libchaosvmp.so"
     $lib3  = "libxloader.so"
     $asset = "assets/maindata/fake_classes.dex"


### PR DESCRIPTION
there's also `libhdog.so` variant which is already included in our rules as "Crazy Dog Wrapper", so not added in this.