### PR TITLE
Updated and added Google Pairip/Play Integrity Rules

### DIFF
--- a/apkid/rules/dex/protectors.yara
+++ b/apkid/rules/dex/protectors.yara
@@ -587,7 +587,7 @@ rule google_playintegrity_api : protector
   strings:
     $class_prefix = { 00 [1-5] 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F
                       69 64 2F 70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69
-                      74 79 2F} // Lcom/google/android/play/core/integrity
+                      74 79 2F} // Lcom/google/android/play/core/integrity/
 
   condition:
     is_dex and all of them

--- a/apkid/rules/dex/protectors.yara
+++ b/apkid/rules/dex/protectors.yara
@@ -572,7 +572,7 @@ rule google_AIP_Installer_Check : protector
                76 69 64 65 72 3B 00 } // Lcom/pairip/licensecheck/LicenseContentProvider;
 
   condition:
-    is_dex and $class
+    is_dex and any of them
 }
 
 rule google_playintegrity_api : protector
@@ -584,29 +584,9 @@ rule google_playintegrity_api : protector
     author      = "Ivan Baheux"
 
   strings:
-    $class = { 00 39 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
-               70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 49
-               6E 74 65 67 72 69 74 79 4D 61 6E 61 67 65 72 3B 00 } // Lcom/google/android/play/core/integrity/IntegrityManager;
-    $class2 = { 00 40 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
-                70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 49
-                6E 74 65 67 72 69 74 79 4D 61 6E 61 67 65 72 46 61 63 74 6F 72
-                79 3B 00 } // Lcom/google/android/play/core/integrity/IntegrityManagerFactory;
-    $class3 = { 00 42 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
-                70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 49
-                6E 74 65 67 72 69 74 79 53 65 72 76 69 63 65 45 78 63 65 70 74
-                69 6F 6E 3B 00 } // Lcom/google/android/play/core/integrity/IntegrityServiceException;
-    $class4 = { 00 3E 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
-                70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 49
-                6E 74 65 67 72 69 74 79 54 6F 6B 65 6E 52 65 71 75 65 73 74 3B
-                00 } // Lcom/google/android/play/core/integrity/IntegrityTokenRequest;
-    $class5 = { 00 3F 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
-                70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 49
-                6E 74 65 67 72 69 74 79 54 6F 6B 65 6E 52 65 73 70 6F 6E 73 65
-                3B 00 } // Lcom/google/android/play/core/integrity/IntegrityTokenResponse;
-    $class6 = { 00 41 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
-                70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 6D
-                6F 64 65 6C 2F 49 6E 74 65 67 72 69 74 79 45 72 72 6F 72 43 6F
-                64 65 3B 00 } // Lcom/google/android/play/core/integrity/model/IntegrityErrorCode;
+    $class_prefix = { 00 [1-5] 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F
+                      69 64 2F 70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69
+                      74 79 } // Lcom/google/android/play/core/integrity
 
   condition:
     is_dex and any of them

--- a/apkid/rules/dex/protectors.yara
+++ b/apkid/rules/dex/protectors.yara
@@ -558,11 +558,11 @@ rule bureau : protector
     is_dex and any of them
 }
 
-rule google_automatic_integrity_protection_install_check : protector
+rule google_AIP_Installer_Check : protector
 {
   meta:
-    description = "Google AIP (Installer check)"
-    url         = "https://support.google.com/googleplay/android-developer/answer/10183279?sjid=8716010463058243647-EU"
+    description = "Google AIP (Installer check)" // Google Automatic Integrity Protection
+    url         = "https://support.google.com/googleplay/android-developer/answer/10183279"
     sample      = "f09336a3473597e794f9b5775d80a578685cde5ef39018b0578c2b894d6b0674" // com.chessbar.apk
     author      = "Ivan Baheux"
 
@@ -575,10 +575,10 @@ rule google_automatic_integrity_protection_install_check : protector
     is_dex and $class
 }
 
-rule google_integrity_api : protector
+rule google_playintegrity_api : protector
 {
   meta:
-    description = "Google Integrity API"
+    description = "Google Play Integrity API"
     url         = "https://developer.android.com/google/play/integrity/overview"
     sample      = "f09336a3473597e794f9b5775d80a578685cde5ef39018b0578c2b894d6b0674" // com.chessbar.apk
     author      = "Ivan Baheux"

--- a/apkid/rules/dex/protectors.yara
+++ b/apkid/rules/dex/protectors.yara
@@ -558,11 +558,12 @@ rule bureau : protector
     is_dex and any of them
 }
 
-rule google_AIP_Installer_Check : protector
+rule google_aip_installer_check : protector
 {
   meta:
-    description = "Google AIP (Installer check)" // Google Automatic Integrity Protection
-    url         = "https://support.google.com/googleplay/android-developer/answer/10183279"
+    description = "Google Automatic Integrity (Installer check)" // Google Automatic Integrity Protection
+    url         = "https://developer.android.com/google/play/integrity/overview"
+    url2        = "https://support.google.com/googleplay/android-developer/answer/10183279"
     sample      = "f09336a3473597e794f9b5775d80a578685cde5ef39018b0578c2b894d6b0674" // com.chessbar.apk
     author      = "Ivan Baheux"
 
@@ -572,7 +573,7 @@ rule google_AIP_Installer_Check : protector
                76 69 64 65 72 3B 00 } // Lcom/pairip/licensecheck/LicenseContentProvider;
 
   condition:
-    is_dex and any of them
+    is_dex and all of them
 }
 
 rule google_playintegrity_api : protector
@@ -586,8 +587,8 @@ rule google_playintegrity_api : protector
   strings:
     $class_prefix = { 00 [1-5] 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F
                       69 64 2F 70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69
-                      74 79 } // Lcom/google/android/play/core/integrity
+                      74 79 2F} // Lcom/google/android/play/core/integrity
 
   condition:
-    is_dex and any of them
+    is_dex and all of them
 }

--- a/apkid/rules/dex/protectors.yara
+++ b/apkid/rules/dex/protectors.yara
@@ -561,7 +561,7 @@ rule bureau : protector
 rule google_automatic_integrity_protection_install_check : protector
 {
   meta:
-    description = "Google Automatic Integrity Protection (Installer check only)"
+    description = "Google AIP (Installer check)"
     url         = "https://support.google.com/googleplay/android-developer/answer/10183279?sjid=8716010463058243647-EU"
     sample      = "f09336a3473597e794f9b5775d80a578685cde5ef39018b0578c2b894d6b0674" // com.chessbar.apk
     author      = "Ivan Baheux"

--- a/apkid/rules/dex/protectors.yara
+++ b/apkid/rules/dex/protectors.yara
@@ -579,7 +579,7 @@ rule google_aip_installer_check : protector
 rule google_playintegrity_api : protector
 {
   meta:
-    description = "Google Play Integrity API"
+    description = "Play Integrity API"
     url         = "https://developer.android.com/google/play/integrity/overview"
     sample      = "f09336a3473597e794f9b5775d80a578685cde5ef39018b0578c2b894d6b0674" // com.chessbar.apk
     author      = "Ivan Baheux"

--- a/apkid/rules/dex/protectors.yara
+++ b/apkid/rules/dex/protectors.yara
@@ -557,3 +557,57 @@ rule bureau : protector
   condition:
     is_dex and any of them
 }
+
+rule google_automatic_integrity_protection_install_check : protector
+{
+  meta:
+    description = "Google Automatic Integrity Protection (Installer check only)"
+    url         = "https://support.google.com/googleplay/android-developer/answer/10183279?sjid=8716010463058243647-EU"
+    sample      = "f09336a3473597e794f9b5775d80a578685cde5ef39018b0578c2b894d6b0674" // com.chessbar.apk
+    author      = "Ivan Baheux"
+
+  strings:
+    $class = { 00 30 4C 63 6F 6D 2F 70 61 69 72 69 70 2F 6C 69 63 65 6E 73 65 63
+               68 65 63 6B 2F 4C 69 63 65 6E 73 65 43 6F 6E 74 65 6E 74 50 72 6F
+               76 69 64 65 72 3B 00 } // Lcom/pairip/licensecheck/LicenseContentProvider;
+
+  condition:
+    is_dex and $class
+}
+
+rule google_integrity_api : protector
+{
+  meta:
+    description = "Google Integrity API"
+    url         = "https://developer.android.com/google/play/integrity/overview"
+    sample      = "f09336a3473597e794f9b5775d80a578685cde5ef39018b0578c2b894d6b0674" // com.chessbar.apk
+    author      = "Ivan Baheux"
+
+  strings:
+    $class = { 00 39 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
+               70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 49
+               6E 74 65 67 72 69 74 79 4D 61 6E 61 67 65 72 3B 00 } // Lcom/google/android/play/core/integrity/IntegrityManager;
+    $class2 = { 00 40 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
+                70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 49
+                6E 74 65 67 72 69 74 79 4D 61 6E 61 67 65 72 46 61 63 74 6F 72
+                79 3B 00 } // Lcom/google/android/play/core/integrity/IntegrityManagerFactory;
+    $class3 = { 00 42 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
+                70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 49
+                6E 74 65 67 72 69 74 79 53 65 72 76 69 63 65 45 78 63 65 70 74
+                69 6F 6E 3B 00 } // Lcom/google/android/play/core/integrity/IntegrityServiceException;
+    $class4 = { 00 3E 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
+                70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 49
+                6E 74 65 67 72 69 74 79 54 6F 6B 65 6E 52 65 71 75 65 73 74 3B
+                00 } // Lcom/google/android/play/core/integrity/IntegrityTokenRequest;
+    $class5 = { 00 3F 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
+                70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 49
+                6E 74 65 67 72 69 74 79 54 6F 6B 65 6E 52 65 73 70 6F 6E 73 65
+                3B 00 } // Lcom/google/android/play/core/integrity/IntegrityTokenResponse;
+    $class6 = { 00 41 4C 63 6F 6D 2F 67 6F 6F 67 6C 65 2F 61 6E 64 72 6F 69 64 2F
+                70 6C 61 79 2F 63 6F 72 65 2F 69 6E 74 65 67 72 69 74 79 2F 6D
+                6F 64 65 6C 2F 49 6E 74 65 67 72 69 74 79 45 72 72 6F 72 43 6F
+                64 65 3B 00 } // Lcom/google/android/play/core/integrity/model/IntegrityErrorCode;
+
+  condition:
+    is_dex and any of them
+}

--- a/apkid/rules/elf/protectors.yara
+++ b/apkid/rules/elf/protectors.yara
@@ -463,7 +463,7 @@ rule protectt : protector
     is_elf and 1 of them
 }
 
-rule google_aip_advanced : protector
+rule google_aip_elf : protector
 {
   meta:
     description = "Google Automatic Integrity" // Google Automatic Integrity Protection

--- a/apkid/rules/elf/protectors.yara
+++ b/apkid/rules/elf/protectors.yara
@@ -466,7 +466,7 @@ rule protectt : protector
 rule googleIntegrityProtection : protector
 {
   meta:
-    description = "Google Automatic Integrity Protection (Tamper protection and device check only)"
+    description = "Google AIP (Tamper and device check)"
     url         = "https://support.google.com/googleplay/android-developer/answer/10183279?sjid=8716010463058243647-EU"
     sample      = "607e256868c012dda10aaff07fdd24928d86122c715078406fb21aae7a2b8a44"
     author      = "Eduardo Novella"

--- a/apkid/rules/elf/protectors.yara
+++ b/apkid/rules/elf/protectors.yara
@@ -463,12 +463,12 @@ rule protectt : protector
     is_elf and 1 of them
 }
 
-rule google_AIP_Advanced : protector
+rule google_aip_advanced : protector
 {
   meta:
-    description = "Google AIP (Tamper and device check)" // Google Automatic Integrity Protection
-    url         = "https://support.google.com/googleplay/android-developer/answer/10183279"
-    sample      = "607e256868c012dda10aaff07fdd24928d86122c715078406fb21aae7a2b8a44"
+    description = "Google Automatic Integrity" // Google Automatic Integrity Protection
+    url         = "https://developer.android.com/google/play/integrity/overview"
+    url2        = "https://support.google.com/googleplay/android-developer/answer/10183279"    sample      = "607e256868c012dda10aaff07fdd24928d86122c715078406fb21aae7a2b8a44"
     author      = "Eduardo Novella"
 
     strings:

--- a/apkid/rules/elf/protectors.yara
+++ b/apkid/rules/elf/protectors.yara
@@ -466,8 +466,8 @@ rule protectt : protector
 rule googleIntegrityProtection : protector
 {
   meta:
-    description = "Google Play Integrity"
-    url         = "https://developer.android.com/games/playgames/integrity"
+    description = "Google Automatic Integrity Protection (Tamper protection and device check only)"
+    url         = "https://support.google.com/googleplay/android-developer/answer/10183279?sjid=8716010463058243647-EU"
     sample      = "607e256868c012dda10aaff07fdd24928d86122c715078406fb21aae7a2b8a44"
     author      = "Eduardo Novella"
 

--- a/apkid/rules/elf/protectors.yara
+++ b/apkid/rules/elf/protectors.yara
@@ -463,11 +463,11 @@ rule protectt : protector
     is_elf and 1 of them
 }
 
-rule googleIntegrityProtection : protector
+rule google_AIP_Advanced : protector
 {
   meta:
-    description = "Google AIP (Tamper and device check)"
-    url         = "https://support.google.com/googleplay/android-developer/answer/10183279?sjid=8716010463058243647-EU"
+    description = "Google AIP (Tamper and device check)" // Google Automatic Integrity Protection
+    url         = "https://support.google.com/googleplay/android-developer/answer/10183279"
     sample      = "607e256868c012dda10aaff07fdd24928d86122c715078406fb21aae7a2b8a44"
     author      = "Eduardo Novella"
 


### PR DESCRIPTION
Fixes https://github.com/rednaga/APKiD/issues/495

# Tests :

- air.com.unit9.bkFrApp.apk 
```
$ ./docker/apkid.sh air.com.unit9.bkFrApp.apk 
[+] APKiD 3.1.0 :: from RedNaga :: rednaga.io
[*] /input/air.com.unit9.bkFrApp.apk!classes.dex
 |-> anti_vm : Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, possible VM check
 |-> compiler : r8
 |-> protector : Google Integrity API
[*] /input/air.com.unit9.bkFrApp.apk!classes2.dex
 |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, SIM operator check, network operator name check, possible Build.SERIAL check
 |-> compiler : r8 without marker (suspicious)
 |-> protector : Google Automatic Integrity Protection (Installer check only)
[*] /input/air.com.unit9.bkFrApp.apk!classes3.dex
 |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, SIM operator check, network operator name check, subscriber ID check
 |-> compiler : r8 without marker (suspicious)
[*] /input/air.com.unit9.bkFrApp.apk!classes4.dex
 |-> anti_vm : Build.FINGERPRINT check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, SIM operator check, network operator name check, possible Build.SERIAL check, possible VM check, ro.kernel.qemu check
 |-> compiler : r8 without marker (suspicious)
 |-> protector : Google Integrity API
[*] /input/air.com.unit9.bkFrApp.apk!classes5.dex
 |-> anti_vm : Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.TAGS check
 |-> compiler : r8 without marker (suspicious)
 |-> protector : Google Integrity API
[*] /input/air.com.unit9.bkFrApp.apk!classes6.dex
 |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, network operator name check, possible Build.SERIAL check, possible VM check
 |-> compiler : r8 without marker (suspicious)
[*] /input/air.com.unit9.bkFrApp.apk!classes7.dex
 |-> anti_debug : Debug.isDebuggerConnected() check
 |-> anti_vm : Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, possible VM check
 |-> compiler : r8 without marker (suspicious)
[*] /input/air.com.unit9.bkFrApp.apk!classes8.dex
 |-> compiler : r8 without marker (suspicious)
[*] /input/air.com.unit9.bkFrApp.apk!classes9.dex
 |-> compiler : r8 without marker (suspicious)
```
- com.chessbar.apk
```
$ ./docker/apkid.sh ../../chess/ChessBar_1.5.23_apkcombo.com.xapk 
[+] APKiD 3.1.0 :: from RedNaga :: rednaga.io
[*] /input/ChessBar_1.5.23_apkcombo.com.xapk!com.chessbar.apk!classes.dex
 |-> anti_debug : Debug.isDebuggerConnected() check
 |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check, SIM operator check, network operator name check, possible Build.SERIAL check, possible VM check, ro.hardware check, ro.kernel.qemu check
 |-> compiler : r8
 |-> protector : Google Automatic Integrity Protection (Installer check only), Google Integrity API
[*] /input/ChessBar_1.5.23_apkcombo.com.xapk!com.chessbar.apk!classes2.dex
 |-> compiler : r8
[*] /input/ChessBar_1.5.23_apkcombo.com.xapk!com.chessbar.apk!classes3.dex
 |-> anti_vm : Build.BOARD check, Build.FINGERPRINT check, Build.HARDWARE check, Build.MANUFACTURER check, Build.MODEL check, Build.PRODUCT check, Build.TAGS check
 |-> compiler : r8
 |-> protector : Google Integrity API
[*] /input/ChessBar_1.5.23_apkcombo.com.xapk!com.chessbar.apk!classes4.dex
 |-> compiler : r8
```